### PR TITLE
Remove developer mode which skips license check

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ if (valid) {
 }
 ```
 
-Before building for production, paste your public key (from `susi-admin keygen`) into the `DEFAULT_PUBLIC_KEY` constant in `susi.cpp`. When the key is empty, license checks are skipped (development mode).
+Before building for production, paste your public key (from `susi-admin keygen`) into the `DEFAULT_PUBLIC_KEY` constant in `susi.cpp`.
 
 To use your own logging framework instead of `fprintf`, define `SUSI_LOG` before including `susi.cpp`:
 

--- a/cpp/susi.cpp
+++ b/cpp/susi.cpp
@@ -312,11 +312,6 @@ bool SusiClient::checkLicense(std::string jsonLicenseInfo)
     m_features.clear();
     m_leaseExpiresEpoch = 0;
 
-    if (std::string(DEFAULT_PUBLIC_KEY).empty()) {
-        SUSI_LOG("No public key compiled in, skipping license check");
-        return true;
-    }
-
     json info;
     try {
         info = json::parse(jsonLicenseInfo);
@@ -632,7 +627,7 @@ static bool hkdfSha256(
         HMAC_CTX_free(ctx);
         tLen = len;
 
-        size_t copyLen = std::min(tLen, okmLen - offset);
+        size_t copyLen = (std::min)(tLen, okmLen - offset);
         memcpy(okm + offset, t, copyLen);
         offset += copyLen;
         counter++;
@@ -693,11 +688,6 @@ bool SusiClient::checkLicenseToken()
 {
     m_features.clear();
     m_leaseExpiresEpoch = 0;
-
-    if (std::string(DEFAULT_PUBLIC_KEY).empty()) {
-        SUSI_LOG("No public key compiled in, skipping license check");
-        return true;
-    }
 
     auto devices = enumerateUsbDevices();
     if (devices.empty()) {

--- a/cpp/susi.cpp
+++ b/cpp/susi.cpp
@@ -288,7 +288,6 @@ static bool isExpired(const json& payload)
 
 // Default embedded public key.
 // Replace this with your actual public key generated via: susi-admin keygen
-// When empty, license check is skipped (development mode).
 static const char* DEFAULT_PUBLIC_KEY = "";
 
 static std::string getPublicKeyPem()


### PR DESCRIPTION
- Remove the "developer mode" feature from the C++ client. It skiped the license check when the DEFAULT_PUBLIC_KEY is empty, which could be exploited by removing the public key from the executable.
- Fix small compilation error on windows