### PR TITLE
Hardware token license files now include the USB serial as machine code

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Instead of binding a license to a specific machine, you can bind it to a physica
 3. The encrypted blob is written to `<usb_mount>/.susi/license.bin`
 4. At runtime, the client scans connected USB drives for this file, decrypts it using the device's serial, and verifies the RSA signature as usual
 
-Token-bound licenses have empty `machine_codes`, so they are not tied to any specific machine.
+Token-bound licenses have a machine code based on the serial number of the USB stick: `usb:<serial>`.
 
 ### Export a license to a USB token
 

--- a/cpp/include/susi.h
+++ b/cpp/include/susi.h
@@ -20,7 +20,9 @@ public:
 
     std::string getPublicKeyPem();
 
-    bool verifySignedLicenseJson(std::string signedLicenseStr);
+    /// Checks if license is signed correctly and still valid.
+    /// If no activation code is given to check against, the local machine code is used.
+    bool verifySignedLicenseJson(std::string signedLicenseStr, std::string activationCode = "");
     bool checkLicense(std::string jsonLicenseInfo);
     bool checkLicenseToken();
     /// Contact the activation server to refresh the lease, then verify the license.

--- a/cpp/src/susi.cpp
+++ b/cpp/src/susi.cpp
@@ -358,7 +358,7 @@ std::string SusiClient::getPublicKeyPem()
 // ---------------------------------------------------------------------------
 // Shared license verify logic
 // ---------------------------------------------------------------------------
-bool SusiClient::verifySignedLicenseJson(std::string signedLicenseStr)
+bool SusiClient::verifySignedLicenseJson(std::string signedLicenseStr, std::string activationCode)
 {
     json signedLicense;
     try {
@@ -408,16 +408,18 @@ bool SusiClient::verifySignedLicenseJson(std::string signedLicenseStr)
     if (payload.contains("machine_codes") && payload.at("machine_codes").is_array()) {
         const auto& codes = payload.at("machine_codes");
         if (!codes.empty()) {
-            std::string localCode = getMachineCode();
+            if(activationCode.empty()){
+                activationCode = getMachineCode();
+            }
             bool found = false;
             for (const auto& code : codes) {
-                if (code.is_string() && code.get<std::string>() == localCode) {
+                if (code.is_string() && code.get<std::string>() == activationCode) {
                     found = true;
                     break;
                 }
             }
             if (!found) {
-                SUSI_LOG("License not valid for this machine (code: %s)", localCode.c_str());
+                SUSI_LOG("License not valid for this machine (code: %s)", activationCode.c_str());
                 return false;
             }
         }
@@ -827,7 +829,9 @@ bool SusiClient::checkLicenseToken()
         std::string decrypted = decryptToken(blob, dev.serial);
         if (decrypted.empty()) continue;
 
-        if (!verifySignedLicenseJson(decrypted)) {
+        std::string usbActivationCode = "usb:" + dev.serial;
+
+        if (!verifySignedLicenseJson(decrypted, usbActivationCode)) {
             continue;
         }
 

--- a/crates/susi_admin/src/main.rs
+++ b/crates/susi_admin/src/main.rs
@@ -534,7 +534,7 @@ fn cmd_export_token(
         created: license.created,
         expires: license.expires,
         features: license.features.clone(),
-        machine_codes: vec![],
+        machine_codes: vec![activation_code],
         lease_expires: None,
     };
 

--- a/crates/susi_client/src/lib.rs
+++ b/crates/susi_client/src/lib.rs
@@ -132,8 +132,25 @@ impl LicenseClient {
         self.verify_signed(&signed)
     }
 
-    /// Verify a SignedLicense object (e.g. received from server or loaded from disk).
+     /// Verify a SignedLicense object (e.g. received from server or loaded from disk).
+     /// Use local machine code for machine check.
     pub fn verify_signed(&self, signed: &SignedLicense) -> LicenseStatus {
+        match fingerprint::get_machine_code() {
+            Ok(local_code) => {
+                return self.verify_signed_with_activation_code(signed, &local_code);
+            }
+            Err(e) => {
+                return LicenseStatus::Error(format!(
+                    "Could not compute machine fingerprint: {}",
+                    e
+                ));
+            }
+        }
+    }
+
+    /// Verify a SignedLicense object (e.g. received from server or loaded from disk).
+    /// Use given activation code for machine check.
+    pub fn verify_signed_with_activation_code(&self, signed: &SignedLicense, activation_code: &str) -> LicenseStatus {
         let payload = match verify_license(&self.public_key, signed) {
             Ok(p) => p,
             Err(LicenseError::InvalidSignature) => return LicenseStatus::InvalidSignature,
@@ -147,23 +164,11 @@ impl LicenseClient {
         }
 
         // Check machine code if the payload has machine restrictions
-        if !payload.machine_codes.is_empty() {
-            match fingerprint::get_machine_code() {
-                Ok(local_code) => {
-                    if !payload.is_machine_authorized(&local_code) {
-                        return LicenseStatus::InvalidMachine {
-                            expected: payload.machine_codes.clone(),
-                            actual: local_code,
-                        };
-                    }
-                }
-                Err(e) => {
-                    return LicenseStatus::Error(format!(
-                        "Could not compute machine fingerprint: {}",
-                        e
-                    ));
-                }
-            }
+        if !payload.is_machine_authorized(&activation_code) {
+            return LicenseStatus::InvalidMachine {
+                expected: payload.machine_codes.clone(),
+                actual: activation_code.to_string(),
+            };
         }
 
         // Check lease expiry
@@ -262,7 +267,8 @@ impl LicenseClient {
 
             match susi_core::token::read_token(&device.mount_path, &device.serial) {
                 Ok(signed) => {
-                    let status = self.verify_signed(&signed);
+                    let activation_code = format!("usb:{}", device.serial);
+                    let status = self.verify_signed_with_activation_code(&signed, &activation_code);
                     if status.is_valid() {
                         return status;
                     }


### PR DESCRIPTION
License files stored on hardware tokens now include a machine code based on the serial number. This fixes a vulnerability which allowed to extract the license file from a usb drive and then use it on any machine because it was not bound to a specific machine code. The client checks licenses from USB drives against their serial number.

Token-bound licenses created with this fix will not work on old clients.