### PR TITLE
Feature/License Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,76 @@ Lease parameters are set per-license at creation time, so different customers ca
 
 Set `--lease-duration 0` when creating a license to disable lease enforcement entirely. Machine activations become permanent (the original behavior), suitable for trusted customers or air-gapped environments.
 
+## License Properties File
+
+A **license properties file** (`susi-properties.json`) lets you, as the software vendor, control which licensing methods your application allows and also which server URL is used for online verification. This allows you to change the licensing method, without changing any code or making a new release.
+
+### Create a properties file
+
+```bash
+# Allow only file-based licenses
+susi-admin properties \
+  --methods file \
+  --private-key ./keys/private.pem
+
+# Allow server activation first, fall back to file
+susi-admin properties \
+  --methods server,file \
+  --server-url https://license.example.com/api/v1 \
+  --private-key ./keys/private.pem
+
+# All three methods: server → file → USB token
+susi-admin properties \
+  --methods server,file,token \
+  --server-url https://license.example.com/api/v1 \
+  --output susi-properties.json \
+  --private-key ./keys/private.pem
+```
+
+Available methods: `file`, `token`, `server`. The order in `--methods` is preserved and can be used by the implementing application to try verification in this specific order.
+
+### Use a properties file in Rust
+
+```rust
+use susi_client::LicenseClient;
+use std::path::Path;
+
+let client = LicenseClient::from_properties(
+    include_str!("public.pem"),
+    Path::new("susi-properties.json"),
+).unwrap();
+
+// Only methods listed in the properties file are permitted.
+// Calling verify_file() when "file" is not in the properties
+// returns LicenseStatus::LicenseMethodNotAllowed.
+let status = client.verify_and_refresh(
+    Path::new("license.json"),
+    "XXXXX-XXXXX-XXXXX-XXXXX",
+);
+```
+
+### Use a properties file in C++
+
+```cpp
+// Pass the properties file path as the second constructor argument
+SusiClient susi("your-public-key", "susi-properties.json");
+
+// Only methods listed in the properties file are tried.
+// Calling checkLicense() when "file" is not permitted returns LicenseStatus::Error.
+auto status = susi.checkLicenseAndRefresh("license.json", "XXXXX-XXXXX-XXXXX-XXXXX");
+```
+
+### Properties file format
+
+```json
+{
+  "properties_data": "{\"methods\":[{\"type\":\"server\",\"url\":\"https://license.example.com/api/v1\"},{\"type\":\"file\"}]}",
+  "signature": "Base64-encoded RSA-SHA256 signature of properties_data"
+}
+```
+
+The signature is verified against your embedded public key on startup. If the file is missing, tampered with, or signed with a different key, the client refuses to load it.
+
 ## Managing Licenses
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -571,6 +571,7 @@ A **license properties file** (`susi-properties.json`) lets you, as the software
 # Allow only file-based licenses
 susi-admin properties \
   --methods file \
+  --server-url https://license.example.com/api/v1 \
   --private-key ./keys/private.pem
 
 # Allow server activation first, fall back to file
@@ -587,7 +588,7 @@ susi-admin properties \
   --private-key ./keys/private.pem
 ```
 
-Available methods: `file`, `token`, `server`. The order in `--methods` is preserved and can be used by the implementing application to try verification in this specific order.
+`--server-url` is always required. Available methods: `file`, `token`, `server`. The order in `--methods` is preserved and can be used by the implementing application to try verification in this specific order.
 
 ### Use a properties file in Rust
 
@@ -624,7 +625,7 @@ auto status = susi.checkLicenseAndRefresh("license.json", "XXXXX-XXXXX-XXXXX-XXX
 
 ```json
 {
-  "properties_data": "{\"methods\":[{\"type\":\"server\",\"url\":\"https://license.example.com/api/v1\"},{\"type\":\"file\"}]}",
+  "properties_data": "{\"server_url\":\"https://license.example.com/api/v1\",\"methods\":[{\"type\":\"server\"},{\"type\":\"file\"}]}",
   "signature": "Base64-encoded RSA-SHA256 signature of properties_data"
 }
 ```

--- a/cpp/include/susi.h
+++ b/cpp/include/susi.h
@@ -21,6 +21,11 @@ public:
         FileNotFound,
         Error,
     };
+    enum class LicenseMethod {
+        File,
+        Token,
+        Server
+    };
 private:
     bool m_isValid = false;
     std::vector<std::string> m_features;
@@ -30,12 +35,18 @@ private:
     int64_t m_graceHours = 24;
     std::string m_publicKey;
     std::string m_serverUrl;
-
+    std::vector<LicenseMethod> m_allowedLicenseMethods;
 public:
-    SusiClient(std::string publicKey) : m_publicKey(std::move(publicKey)) {}
+    SusiClient(std::string publicKey) : m_publicKey(std::move(publicKey)) {
+        m_allowedLicenseMethods = { LicenseMethod::Token, LicenseMethod::File };
+    }
     /// Create a client with an activation server URL (e.g. "https://license.example.com/api/v1").
     SusiClient(std::string publicKey, std::string serverUrl)
-        : m_publicKey(std::move(publicKey)), m_serverUrl(std::move(serverUrl)) {}
+        : m_publicKey(std::move(publicKey)), m_serverUrl(std::move(serverUrl)) {
+        m_allowedLicenseMethods = { LicenseMethod::Server, LicenseMethod::Token, LicenseMethod::File };
+    }
+    /// Create a client from a properties file
+    SusiClient(std::string publicKey, std::filesystem::path propertiesPath);
 
     std::string getPublicKeyPem();
 
@@ -45,7 +56,7 @@ public:
     LicenseStatus checkLicenseToken();
     /// Contact the activation server to refresh the lease, then verify the license.
     /// Falls back to the cached local file if the server is unreachable.
-    LicenseStatus checkLicenseAndRefresh(const std::filesystem::path& licensePath, const std::string& licenseKey);
+    LicenseStatus checkLicenseAndRefresh(const std::filesystem::path& licenseCachePath, const std::string& licenseKey, const std::string& friendlyName = "");
 
     bool isValid() const { return m_isValid; }
 
@@ -67,6 +78,8 @@ public:
     bool isLeaseExpired() const;
 
     void setGraceHours(int64_t hours) { m_graceHours = hours; }
+
+    const std::vector<LicenseMethod>& allowedLicenseMethods() const { return m_allowedLicenseMethods; }
 private:
     /// Verifies the signature of the signed license JSON string and returns the license status.
     /// If activation code is not provided, the local machine code is used.

--- a/cpp/src/susi.cpp
+++ b/cpp/src/susi.cpp
@@ -512,6 +512,13 @@ SusiClient::SusiClient(std::string publicKey, std::filesystem::path propertiesPa
         return;
     }
 
+    if (!props.contains("server_url") || !props.at("server_url").is_string()
+        || props.at("server_url").get<std::string>().empty()) {
+        SUSI_LOG("License properties file is not formatted correctly");
+        return;
+    }
+    m_serverUrl = props.at("server_url").get<std::string>();
+
     int countFile = 0;
     int countToken = 0;
     int countServer = 0;
@@ -524,7 +531,6 @@ SusiClient::SusiClient(std::string publicKey, std::filesystem::path propertiesPa
         }
         std::string type = m.at("type").get<std::string>();
 
-        LicenseStatus status = LicenseStatus::Error;
         if (type == "file") {
             m_allowedLicenseMethods.push_back(LicenseMethod::File);
             countFile++;
@@ -532,14 +538,6 @@ SusiClient::SusiClient(std::string publicKey, std::filesystem::path propertiesPa
             m_allowedLicenseMethods.push_back(LicenseMethod::Token);
             countToken++;
         } else if (type == "server") {
-            if (!m.contains("url") || !m.at("url").is_string()){
-                SUSI_LOG("License properties file is not formatted correctly");
-                m_allowedLicenseMethods.clear();
-                return;
-            }
-            std::string url = m.at("url").get<std::string>();
-
-            m_serverUrl = url;
             m_allowedLicenseMethods.push_back(LicenseMethod::Server);
             countServer++;
         } else {

--- a/cpp/src/susi.cpp
+++ b/cpp/src/susi.cpp
@@ -451,6 +451,112 @@ static long httpPost(const std::string& url, const std::string& body, std::strin
     return httpCode;
 }
 
+SusiClient::SusiClient(std::string publicKey, std::filesystem::path propertiesPath) : m_publicKey(std::move(publicKey))
+{
+    // 1. Read the properties file.
+    std::ifstream f(propertiesPath);
+    if (!f.is_open()) {
+        SUSI_LOG("License properties file not found: %s", propertiesPath.string().c_str());
+        return;
+    }
+    std::string contents((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+
+    // 2. Parse the outer SignedLicenseProperties envelope.
+    json signedProps;
+    try {
+        signedProps = json::parse(contents);
+    } catch (const json::exception& e) {
+        SUSI_LOG("License properties file is not formatted correctly");
+        return;
+    }
+    if (!signedProps.contains("properties_data") || !signedProps.contains("signature")) {
+        SUSI_LOG("License properties file is not formatted correctly");
+        return;
+    }
+    std::string propsData;
+    std::string sigB64;
+    try {
+        propsData = signedProps.at("properties_data").get<std::string>();
+        sigB64 = signedProps.at("signature").get<std::string>();
+    } catch (const json::exception& e) {
+        SUSI_LOG("License properties file is not formatted correctly");
+        return;
+    }
+
+    // 3. Verify the RSA-SHA256 signature.
+    auto sigBytes = base64Decode(sigB64);
+    if (sigBytes.empty()) {
+        SUSI_LOG("License properties file is not formatted correctly");
+        return;
+    }
+    if (!verifySignature(getPublicKeyPem(), propsData, sigBytes)) {
+        SUSI_LOG("License properties signature verification failed");
+        return;
+    }
+
+    // 4. Parse the properties payload.
+    json props;
+    try {
+        props = json::parse(propsData);
+    } catch (const json::exception& e) {
+        SUSI_LOG("License properties file is not formatted correctly");
+        return;
+    }
+    if (!props.contains("methods") || !props.at("methods").is_array()) {
+        SUSI_LOG("License properties file is not formatted correctly");
+        return;
+    }
+    const auto& methods = props.at("methods");
+    if (methods.empty()) {
+        SUSI_LOG("License properties file is not formatted correctly");
+        return;
+    }
+
+    int countFile = 0;
+    int countToken = 0;
+    int countServer = 0;
+
+    for (const auto& m : methods) {
+        if (!m.is_object() || !m.contains("type") || !m.at("type").is_string()) {
+            SUSI_LOG("License properties file is not formatted correctly");
+            m_allowedLicenseMethods.clear();
+            return;
+        }
+        std::string type = m.at("type").get<std::string>();
+
+        LicenseStatus status = LicenseStatus::Error;
+        if (type == "file") {
+            m_allowedLicenseMethods.push_back(LicenseMethod::File);
+            countFile++;
+        } else if (type == "token") {
+            m_allowedLicenseMethods.push_back(LicenseMethod::Token);
+            countToken++;
+        } else if (type == "server") {
+            if (!m.contains("url") || !m.at("url").is_string()){
+                SUSI_LOG("License properties file is not formatted correctly");
+                m_allowedLicenseMethods.clear();
+                return;
+            }
+            std::string url = m.at("url").get<std::string>();
+
+            m_serverUrl = url;
+            m_allowedLicenseMethods.push_back(LicenseMethod::Server);
+            countServer++;
+        } else {
+            SUSI_LOG("License properties file is not formatted correctly");
+            m_allowedLicenseMethods.clear();
+            return;
+        }
+    }
+
+    if(countFile + countServer + countToken == 0
+        || countFile > 1
+        || countServer > 1
+        || countToken > 1){
+        SUSI_LOG("License properties file is not formatted correctly");
+        m_allowedLicenseMethods.clear();
+    }
+}
 
 std::string SusiClient::getPublicKeyPem()
 {
@@ -606,6 +712,12 @@ SusiClient::LicenseStatus SusiClient::checkLicense(const std::filesystem::path& 
     m_customer.clear();
     m_leaseExpiresEpoch = 0;
 
+    if(std::find(m_allowedLicenseMethods.begin(), m_allowedLicenseMethods.end(), LicenseMethod::File) == m_allowedLicenseMethods.end()){
+        SUSI_LOG("File-based license check is not allowed by properties.");
+        m_isValid = false;
+        return LicenseStatus::Error;
+    }
+
     std::ifstream licenseFile(licensePath);
     if (!licenseFile.is_open()) {
         SUSI_LOG("License file not found: %s", licensePath.string().c_str());
@@ -622,12 +734,18 @@ SusiClient::LicenseStatus SusiClient::checkLicense(const std::filesystem::path& 
 // ---------------------------------------------------------------------------
 // Online license check
 // ---------------------------------------------------------------------------
-SusiClient::LicenseStatus SusiClient::checkLicenseAndRefresh(const std::filesystem::path& licensePath, const std::string& licenseKey)
+SusiClient::LicenseStatus SusiClient::checkLicenseAndRefresh(const std::filesystem::path& licenseCachePath, const std::string& licenseKey, const std::string& friendlyName)
 {
     m_features.clear();
     m_product.clear();
     m_customer.clear();
     m_leaseExpiresEpoch = 0;
+
+    if(std::find(m_allowedLicenseMethods.begin(), m_allowedLicenseMethods.end(), LicenseMethod::Server) == m_allowedLicenseMethods.end()){
+        SUSI_LOG("Server license check is not allowed by properties.");
+        m_isValid = false;
+        return LicenseStatus::Error;
+    }
 
     if (!m_serverUrl.empty()) {
         std::string url = m_serverUrl;
@@ -637,7 +755,7 @@ SusiClient::LicenseStatus SusiClient::checkLicenseAndRefresh(const std::filesyst
         json body;
         body["license_key"] = licenseKey;
         body["machine_code"] = getMachineCode();
-        body["friendly_name"] = getHostname();
+        body["friendly_name"] = friendlyName.empty() ? getHostname() : friendlyName;
 
         std::string response;
         long httpCode = httpPost(url, body.dump(), response);
@@ -646,7 +764,7 @@ SusiClient::LicenseStatus SusiClient::checkLicenseAndRefresh(const std::filesyst
             m_isValid = (status == LicenseStatus::Valid || status == LicenseStatus::ValidGracePeriod);
 
             if (m_isValid) {
-                std::ofstream f(licensePath);
+                std::ofstream f(licenseCachePath);
                 if (f.is_open()) {
                     f << response;
                 }
@@ -654,7 +772,7 @@ SusiClient::LicenseStatus SusiClient::checkLicenseAndRefresh(const std::filesyst
 
             return status;
         } else if (httpCode == 403) {
-            std::filesystem::remove(licensePath);
+            std::filesystem::remove(licenseCachePath);
             m_isValid = false;
 
             if (response.find("revoked") != std::string::npos){
@@ -672,7 +790,7 @@ SusiClient::LicenseStatus SusiClient::checkLicenseAndRefresh(const std::filesyst
             }
         } else if (httpCode == 404) {
             SUSI_LOG("License not found on server (HTTP 404) - removing cached file");
-            std::filesystem::remove(licensePath);
+            std::filesystem::remove(licenseCachePath);
             m_isValid = false;
             return LicenseStatus::InvalidLicenseKey;
         } else {
@@ -683,9 +801,9 @@ SusiClient::LicenseStatus SusiClient::checkLicenseAndRefresh(const std::filesyst
     }
 
     // Fall back to local file
-    std::ifstream licenseFile(licensePath);
+    std::ifstream licenseFile(licenseCachePath);
     if (!licenseFile.is_open()) {
-        SUSI_LOG("Cached license file cannot be found: %s", licensePath.string().c_str());
+        SUSI_LOG("Cached license file cannot be found: %s", licenseCachePath.string().c_str());
         m_isValid = false;
         return LicenseStatus::FileNotFound;
     }
@@ -1136,6 +1254,12 @@ SusiClient::LicenseStatus SusiClient::checkLicenseToken()
     m_product.clear();
     m_customer.clear();
     m_leaseExpiresEpoch = 0;
+
+    if(std::find(m_allowedLicenseMethods.begin(), m_allowedLicenseMethods.end(), LicenseMethod::Token) == m_allowedLicenseMethods.end()){
+        SUSI_LOG("Token-based license check is not allowed by properties.");
+        m_isValid = false;
+        return LicenseStatus::Error;
+    }
 
     auto devices = enumerateUsbDevices();
     if (devices.empty()) {

--- a/crates/susi_admin/src/main.rs
+++ b/crates/susi_admin/src/main.rs
@@ -145,9 +145,9 @@ enum Commands {
         /// Ordered comma-separated list of methods: file, token, server
         #[arg(long, required = true)]
         methods: String,
-        /// License server URL (required when `server` is in --methods)
-        #[arg(long)]
-        server_url: Option<String>,
+        /// License server URL
+        #[arg(long, required = true)]
+        server_url: String,
         /// Output file for the signed properties json
         #[arg(long, default_value = "susi-properties.json")]
         output: String,
@@ -204,7 +204,7 @@ fn main() -> Result<()> {
             server_url,
             output,
             private_key,
-        } => cmd_properties(&methods, server_url, &output, &private_key),
+        } => cmd_properties(&methods, &server_url, &output, &private_key),
     }
 }
 
@@ -599,54 +599,45 @@ fn truncate(s: &str, max: usize) -> String {
 
 fn cmd_properties(
     methods_str: &str,
-    server_url: Option<String>,
+    server_url: &str,
     output: &str,
     private_key_path: &str,
 ) -> Result<()> {
-    let methods = parse_methods(methods_str, server_url.as_deref())?;
+    let methods = parse_methods(methods_str)?;
 
     let priv_pem = std::fs::read_to_string(private_key_path)
         .with_context(|| format!("Failed to read private key from {}", private_key_path))?;
     let private_key = private_key_from_pem(&priv_pem)?;
 
-    let properties = LicenseProperties { methods };
+    let properties = LicenseProperties {
+        server_url: server_url.to_string(),
+        methods,
+    };
     let signed_properties = sign_properties(&private_key, &properties)?;
 
     std::fs::write(output, serde_json::to_string_pretty(&signed_properties)?)
         .with_context(|| format!("Failed to write properties file to {}", output))?;
 
-    println!(
-        "Signed license properties written to: {}",
-        output
-    );
+    println!("Signed license properties written to: {}", output);
+    println!("  Server URL: {}", server_url);
     println!("  Methods:");
     for m in &properties.methods {
         match m {
             LicenseMethod::File => println!("    - file"),
             LicenseMethod::Token => println!("    - token"),
-            LicenseMethod::Server { url } => {
-                println!("    - server: url={}", url);
-            }
+            LicenseMethod::Server => println!("    - server"),
         }
     }
     Ok(())
 }
 
-fn parse_methods(
-    methods_str: &str,
-    server_url: Option<&str>,
-) -> Result<Vec<LicenseMethod>> {
+fn parse_methods(methods_str: &str) -> Result<Vec<LicenseMethod>> {
     let mut methods = Vec::new();
     for raw in methods_str.split(',').map(str::trim).filter(|s| !s.is_empty()) {
         let method = match raw.to_ascii_lowercase().as_str() {
             "file" => LicenseMethod::File,
             "token" => LicenseMethod::Token,
-            "server" => {
-                let url = server_url.ok_or_else(|| {
-                    anyhow::anyhow!("--server-url is required when 'server' is in --methods")
-                })?;
-                LicenseMethod::Server { url: url.to_string() }
-            }
+            "server" => LicenseMethod::Server,
             other => bail!(
                 "Unknown licensing method '{}' (expected file, token, or server)",
                 other
@@ -673,29 +664,23 @@ mod tests {
 
     #[test]
     fn test_parse_methods_all_three_in_order() {
-        let methods = parse_methods("server,file,token", Some("https://ls.example.com")).unwrap();
+        let methods = parse_methods("server,file,token").unwrap();
         assert_eq!(methods.len(), 3);
-        assert!(matches!(&methods[0], LicenseMethod::Server { url } if url == "https://ls.example.com"));
+        assert!(matches!(&methods[0], LicenseMethod::Server));
         assert!(matches!(&methods[1], LicenseMethod::File));
         assert!(matches!(&methods[2], LicenseMethod::Token));
     }
 
     #[test]
-    fn test_parse_methods_server_requires_url() {
-        let err = parse_methods("server", None).unwrap_err();
-        assert!(err.to_string().contains("server-url"));
-    }
-
-    #[test]
     fn test_parse_methods_rejects_unknown() {
-        let err = parse_methods("file,bogus", None).unwrap_err();
+        let err = parse_methods("file,bogus").unwrap_err();
         assert!(err.to_string().contains("Unknown licensing method"));
     }
 
     #[test]
     fn test_parse_methods_rejects_empty() {
-        assert!(parse_methods("", None).is_err());
-        assert!(parse_methods("  , ,", None).is_err());
+        assert!(parse_methods("").is_err());
+        assert!(parse_methods("  , ,").is_err());
     }
 
     #[test]
@@ -705,7 +690,7 @@ mod tests {
         let out_path = tmp("susi-properties.json");
         std::fs::write(&priv_pem_path, private_key_to_pem(&private).unwrap()).unwrap();
 
-        cmd_properties("file,token", None, out_path.to_str().unwrap(), priv_pem_path.to_str().unwrap()).unwrap();
+        cmd_properties("file,token", "https://ls.example.com", out_path.to_str().unwrap(), priv_pem_path.to_str().unwrap()).unwrap();
 
         let content = std::fs::read_to_string(&out_path).unwrap();
         let signed: susi_core::properties::SignedLicenseProperties = serde_json::from_str(&content).unwrap();

--- a/crates/susi_admin/src/main.rs
+++ b/crates/susi_admin/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Context, Result};
 use chrono::{Duration, NaiveDate, Utc};
 use clap::{Parser, Subcommand};
+use susi_core::properties::{sign_properties, LicenseMethod, LicenseProperties};
 use susi_core::crypto::{
     generate_keypair, private_key_from_pem, private_key_to_pem, public_key_to_pem, sign_license,
 };
@@ -137,6 +138,23 @@ enum Commands {
 
     /// Print the hardware fingerprint of this machine
     Fingerprint,
+
+    /// Create and sign a client licensing properties file.
+    #[command(arg_required_else_help = true)]
+    Properties {
+        /// Ordered comma-separated list of methods: file, token, server
+        #[arg(long, required = true)]
+        methods: String,
+        /// License server URL (required when `server` is in --methods)
+        #[arg(long)]
+        server_url: Option<String>,
+        /// Output file for the signed properties json
+        #[arg(long, default_value = "susi-properties.json")]
+        output: String,
+        /// Path to private key PEM file
+        #[arg(long, default_value = "private.pem")]
+        private_key: String,
+    },
 }
 
 fn main() -> Result<()> {
@@ -181,6 +199,12 @@ fn main() -> Result<()> {
             usb_serial,
         } => cmd_export_token(&key, &private_key, &db, &name, usb_serial),
         Commands::Fingerprint => cmd_fingerprint(),
+        Commands::Properties {
+            methods,
+            server_url,
+            output,
+            private_key,
+        } => cmd_properties(&methods, server_url, &output, &private_key),
     }
 }
 
@@ -570,5 +594,127 @@ fn truncate(s: &str, max: usize) -> String {
         format!("{}...", &s[..max - 1])
     } else {
         s.to_string()
+    }
+}
+
+fn cmd_properties(
+    methods_str: &str,
+    server_url: Option<String>,
+    output: &str,
+    private_key_path: &str,
+) -> Result<()> {
+    let methods = parse_methods(methods_str, server_url.as_deref())?;
+
+    let priv_pem = std::fs::read_to_string(private_key_path)
+        .with_context(|| format!("Failed to read private key from {}", private_key_path))?;
+    let private_key = private_key_from_pem(&priv_pem)?;
+
+    let properties = LicenseProperties { methods };
+    let signed_properties = sign_properties(&private_key, &properties)?;
+
+    std::fs::write(output, serde_json::to_string_pretty(&signed_properties)?)
+        .with_context(|| format!("Failed to write properties file to {}", output))?;
+
+    println!(
+        "Signed license properties written to: {}",
+        output
+    );
+    println!("  Methods:");
+    for m in &properties.methods {
+        match m {
+            LicenseMethod::File => println!("    - file"),
+            LicenseMethod::Token => println!("    - token"),
+            LicenseMethod::Server { url } => {
+                println!("    - server: url={}", url);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn parse_methods(
+    methods_str: &str,
+    server_url: Option<&str>,
+) -> Result<Vec<LicenseMethod>> {
+    let mut methods = Vec::new();
+    for raw in methods_str.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        let method = match raw.to_ascii_lowercase().as_str() {
+            "file" => LicenseMethod::File,
+            "token" => LicenseMethod::Token,
+            "server" => {
+                let url = server_url.ok_or_else(|| {
+                    anyhow::anyhow!("--server-url is required when 'server' is in --methods")
+                })?;
+                LicenseMethod::Server { url: url.to_string() }
+            }
+            other => bail!(
+                "Unknown licensing method '{}' (expected file, token, or server)",
+                other
+            ),
+        };
+        methods.push(method);
+    }
+    if methods.is_empty() {
+        bail!("--methods must contain at least one licensing method");
+    }
+    Ok(methods)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use susi_core::properties::verify_properties;
+
+    fn tmp(name: &str) -> std::path::PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        std::env::temp_dir().join(format!("admin_{}_{}_{}", name, std::process::id(), nanos))
+    }
+
+    #[test]
+    fn test_parse_methods_all_three_in_order() {
+        let methods = parse_methods("server,file,token", Some("https://ls.example.com")).unwrap();
+        assert_eq!(methods.len(), 3);
+        assert!(matches!(&methods[0], LicenseMethod::Server { url } if url == "https://ls.example.com"));
+        assert!(matches!(&methods[1], LicenseMethod::File));
+        assert!(matches!(&methods[2], LicenseMethod::Token));
+    }
+
+    #[test]
+    fn test_parse_methods_server_requires_url() {
+        let err = parse_methods("server", None).unwrap_err();
+        assert!(err.to_string().contains("server-url"));
+    }
+
+    #[test]
+    fn test_parse_methods_rejects_unknown() {
+        let err = parse_methods("file,bogus", None).unwrap_err();
+        assert!(err.to_string().contains("Unknown licensing method"));
+    }
+
+    #[test]
+    fn test_parse_methods_rejects_empty() {
+        assert!(parse_methods("", None).is_err());
+        assert!(parse_methods("  , ,", None).is_err());
+    }
+
+    #[test]
+    fn test_cmd_properties_end_to_end() {
+        let (private, public) = generate_keypair(2048).unwrap();
+        let priv_pem_path = tmp("priv.pem");
+        let out_path = tmp("susi-properties.json");
+        std::fs::write(&priv_pem_path, private_key_to_pem(&private).unwrap()).unwrap();
+
+        cmd_properties("file,token", None, out_path.to_str().unwrap(), priv_pem_path.to_str().unwrap()).unwrap();
+
+        let content = std::fs::read_to_string(&out_path).unwrap();
+        let signed: susi_core::properties::SignedLicenseProperties = serde_json::from_str(&content).unwrap();
+        let props = verify_properties(&public, &signed).unwrap();
+        assert_eq!(props.methods.len(), 2);
+        assert!(matches!(&props.methods[0], LicenseMethod::File));
+        assert!(matches!(&props.methods[1], LicenseMethod::Token));
+
+        let _ = std::fs::remove_file(&priv_pem_path);
+        let _ = std::fs::remove_file(&out_path);
     }
 }

--- a/crates/susi_client/src/lib.rs
+++ b/crates/susi_client/src/lib.rs
@@ -95,6 +95,7 @@ impl LicenseStatus {
 /// Client for verifying licenses. Embedded in the FusionHub application.
 pub struct LicenseClient {
     public_key: RsaPublicKey,
+    server_url: Option<String>,
     /// Grace period in hours after lease expiry. Default: 24.
     grace_hours: i64,
     allowed_license_methods: Vec<LicenseMethod>,
@@ -106,6 +107,7 @@ impl LicenseClient {
         let public_key = public_key_from_pem(public_key_pem)?;
         Ok(Self {
             public_key,
+            server_url: None,
             grace_hours: susi_core::DEFAULT_LEASE_GRACE_HOURS as i64,
             allowed_license_methods: vec![LicenseMethod::Token, LicenseMethod::File],
         })
@@ -114,7 +116,8 @@ impl LicenseClient {
     /// Create a new client with an optional server URL for online refresh.
     pub fn with_server(public_key_pem: &str, server_url: String) -> Result<Self, LicenseError> {
         let mut client = Self::new(public_key_pem)?;
-        client.allowed_license_methods = vec![LicenseMethod::Server { url: server_url.clone() }, LicenseMethod::Token, LicenseMethod::File];
+        client.server_url = Some(server_url);
+        client.allowed_license_methods = vec![LicenseMethod::Server, LicenseMethod::Token, LicenseMethod::File];
         Ok(client)
     }
 
@@ -131,6 +134,8 @@ impl LicenseClient {
         };
 
         let properties = verify_properties(&client.public_key, &signed)?;
+
+        client.server_url = Some(properties.server_url);
         client.allowed_license_methods = properties.methods;
         Ok(client)
     }
@@ -218,11 +223,11 @@ impl LicenseClient {
     /// This both renews the lease and verifies the license.
     /// If `friendly_name` is `Some`, use it instead of the system hostname.
     pub fn verify_and_refresh(&self, cache_path: &Path, license_key: &str, friendly_name: Option<&str>) -> LicenseStatus {
-        let Some(server_url) = self.allowed_license_methods.iter().find_map(|m| match m {
-            LicenseMethod::Server { url } => Some(url),
-            _ => None,
-        }) else {
+        if !self.allowed_license_methods.contains(&LicenseMethod::Server) {
             return LicenseStatus::LicenseMethodNotAllowed("Server license check is not allowed by properties.".into());
+        }
+        let Some(server_url) = self.server_url.as_deref() else {
+            return LicenseStatus::Error("Server method is allowed but no server URL is configured.".into());
         };
 
         match self.try_online_activate(server_url, license_key, friendly_name) {
@@ -635,7 +640,7 @@ mod tests {
         let props_path = unique_tmp("props_file_props.json");
         write_signed_license(&private, &make_valid_payload(None), &license_path);
 
-        let props = LicenseProperties { methods: vec![LicenseMethod::File] };
+        let props = LicenseProperties { server_url: "https://license.example.com".to_string(), methods: vec![LicenseMethod::File] };
         write_props(&private, &props, &props_path);
 
         let client = LicenseClient::from_properties(&pub_pem, &props_path).unwrap();
@@ -644,37 +649,6 @@ mod tests {
         assert!(status.has_feature("full_fusion"));
 
         let _ = std::fs::remove_file(&license_path);
-        let _ = std::fs::remove_file(&props_path);
-    }
-
-    #[test]
-    fn test_verify_with_properties_invalid_signature() {
-        let (_, pub_pem, _) = make_keypair_pems();
-        let (_, _, other_private) = make_keypair_pems();
-
-        let props_path = unique_tmp("props_bad_sig.json");
-        let props = LicenseProperties { methods: vec![LicenseMethod::Token] };
-        write_props(&other_private, &props, &props_path);
-
-        let err = LicenseClient::from_properties(&pub_pem, &props_path);
-        assert!(err.is_err(), "expected Err for wrong signing key");
-
-        let _ = std::fs::remove_file(&props_path);
-    }
-
-    #[test]
-    fn test_verify_with_properties_tampered_data() {
-        let (_, pub_pem, private) = make_keypair_pems();
-        let props_path = unique_tmp("props_tampered.json");
-
-        let props = LicenseProperties { methods: vec![LicenseMethod::File] };
-        let mut signed = sign_properties(&private, &props).unwrap();
-        signed.properties_data = signed.properties_data.replace("file", "token");
-        std::fs::write(&props_path, serde_json::to_string(&signed).unwrap()).unwrap();
-
-        let err = LicenseClient::from_properties(&pub_pem, &props_path);
-        assert!(err.is_err(), "expected Err for tampered data");
-
         let _ = std::fs::remove_file(&props_path);
     }
 
@@ -698,30 +672,11 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_with_properties_empty_methods() {
-        let (_, pub_pem, private) = make_keypair_pems();
-        let props_path = unique_tmp("props_empty.json");
-        let props = LicenseProperties { methods: vec![] };
-        write_props(&private, &props, &props_path);
-
-        let client = LicenseClient::from_properties(&pub_pem, &props_path).unwrap();
-        // No methods allowed
-        let status = client.verify_file(Path::new("/tmp/any.json"));
-        assert!(matches!(status, LicenseStatus::LicenseMethodNotAllowed(_)));
-        let status = client.verify_token();
-        assert!(matches!(status, LicenseStatus::LicenseMethodNotAllowed(_)));
-        let status = client.verify_and_refresh(Path::new("/tmp/missing.json"), "AAAA-BBBB-CCCC-DDDD", None);
-        assert!(matches!(status, LicenseStatus::LicenseMethodNotAllowed(_)));
-
-        let _ = std::fs::remove_file(&props_path);
-    }
-
-    #[test]
     fn test_verify_with_properties_only_allowed() {
         // Properties listing only File: verify_file allowed, verify_token blocked.
         let (_, pub_pem, private) = make_keypair_pems();
         let props_path = unique_tmp("props_order.json");
-        let props = LicenseProperties { methods: vec![LicenseMethod::File] };
+        let props = LicenseProperties { server_url: "https://license.example.com".to_string(), methods: vec![LicenseMethod::File] };
         write_props(&private, &props, &props_path);
 
         let client = LicenseClient::from_properties(&pub_pem, &props_path).unwrap();

--- a/crates/susi_client/src/lib.rs
+++ b/crates/susi_client/src/lib.rs
@@ -1,11 +1,12 @@
 pub mod workspace;
 
-use std::path::Path;
+use std::{path::Path, vec};
 
 use chrono::{DateTime, Utc};
 use susi_core::{
     crypto::{public_key_from_pem, verify_license},
     fingerprint, LicenseError, LicensePayload, SignedLicense,
+    properties::{LicenseMethod, SignedLicenseProperties, verify_properties}
 };
 use rsa::RsaPublicKey;
 
@@ -37,6 +38,7 @@ pub enum LicenseStatus {
     Revoked,
     TokenNotFound,
     FileNotFound(String),
+    LicenseMethodNotAllowed(String),
     Error(String),
 }
 
@@ -93,9 +95,9 @@ impl LicenseStatus {
 /// Client for verifying licenses. Embedded in the FusionHub application.
 pub struct LicenseClient {
     public_key: RsaPublicKey,
-    server_url: Option<String>,
     /// Grace period in hours after lease expiry. Default: 24.
     grace_hours: i64,
+    allowed_license_methods: Vec<LicenseMethod>,
 }
 
 impl LicenseClient {
@@ -104,15 +106,32 @@ impl LicenseClient {
         let public_key = public_key_from_pem(public_key_pem)?;
         Ok(Self {
             public_key,
-            server_url: None,
             grace_hours: susi_core::DEFAULT_LEASE_GRACE_HOURS as i64,
+            allowed_license_methods: vec![LicenseMethod::Token, LicenseMethod::File],
         })
     }
 
     /// Create a new client with an optional server URL for online refresh.
     pub fn with_server(public_key_pem: &str, server_url: String) -> Result<Self, LicenseError> {
         let mut client = Self::new(public_key_pem)?;
-        client.server_url = Some(server_url);
+        client.allowed_license_methods = vec![LicenseMethod::Server { url: server_url.clone() }, LicenseMethod::Token, LicenseMethod::File];
+        Ok(client)
+    }
+
+    pub fn from_properties(public_key_pem: &str, properties_path: &Path) -> Result<Self, LicenseError> {
+        let mut client = Self::new(public_key_pem)?;
+        
+        let content = match std::fs::read_to_string(properties_path) {
+            Ok(c) => c,
+            Err(e) => return Err(LicenseError::InvalidProperties(e.to_string())),
+        };
+        let signed: SignedLicenseProperties = match serde_json::from_str(&content) {
+            Ok(s) => s,
+            Err(e) => return Err(LicenseError::InvalidProperties(e.to_string())),
+        };
+
+        let properties = verify_properties(&client.public_key, &signed)?;
+        client.allowed_license_methods = properties.methods;
         Ok(client)
     }
 
@@ -123,6 +142,10 @@ impl LicenseClient {
 
     /// Verify a signed license file on disk.
     pub fn verify_file(&self, path: &Path) -> LicenseStatus {
+        if !self.allowed_license_methods.contains(&LicenseMethod::File) {
+            return LicenseStatus::LicenseMethodNotAllowed("File-based license check is not allowed by properties.".into());
+        }
+
         let content = match std::fs::read_to_string(path) {
             Ok(c) => c,
             Err(e) => return LicenseStatus::FileNotFound(format!("{}: {}", path.display(), e)),
@@ -194,51 +217,54 @@ impl LicenseClient {
     /// Try to refresh the license from the server, falling back to the local file.
     /// This both renews the lease and verifies the license.
     /// If `friendly_name` is `Some`, use it instead of the system hostname.
-    pub fn verify_and_refresh(&self, path: &Path, license_key: &str, friendly_name: Option<&str>) -> LicenseStatus {
-        if let Some(ref server_url) = self.server_url {
-            match self.try_online_activate(server_url, license_key, friendly_name) {
-                Ok(signed) => {
-                    if let Ok(json) = serde_json::to_string_pretty(&signed) {
-                        let _ = std::fs::write(path, json);
-                    }
-                    return self.verify_signed(&signed);
-                }
-                Err(LicenseError::Revoked) => {
-                    log::warn!("License revoked by server - removing cached file");
-                    if let Err(e) = std::fs::remove_file(path) {
-                        if e.kind() != std::io::ErrorKind::NotFound {
-                            log::error!("Failed to remove cached license file: {}", e);
-                        }
-                    }
-                    return LicenseStatus::Revoked;
-                }
-                Err(LicenseError::NotFound) => {
-                    log::warn!("License not found on server - removing cached file");
-                    if let Err(e) = std::fs::remove_file(path) {
-                        if e.kind() != std::io::ErrorKind::NotFound {
-                            log::error!("Failed to remove cached license file: {}", e);
-                        }
-                    }
-                    return LicenseStatus::InvalidLicenseKey;
-                }
-                Err(LicenseError::MachineLimitReached(max)) => {
-                    log::warn!("Cannot activate license - machine limit reached");
-                    return LicenseStatus::Error(format!("Machine limit reached: {}", max));
-                }
-                Err(e) => {
-                    log::warn!("Online license refresh failed, using cached file: {}", e);
-                }
-            }
-        } else {
-            log::warn!("No server supplied. Online license check will fail. Falling back to cached file.");
-        }
+    pub fn verify_and_refresh(&self, cache_path: &Path, license_key: &str, friendly_name: Option<&str>) -> LicenseStatus {
+        let Some(server_url) = self.allowed_license_methods.iter().find_map(|m| match m {
+            LicenseMethod::Server { url } => Some(url),
+            _ => None,
+        }) else {
+            return LicenseStatus::LicenseMethodNotAllowed("Server license check is not allowed by properties.".into());
+        };
 
-        if !path.exists() {
-            return LicenseStatus::Error(format!("Online license check failed, cached license file cannot be found: {}", path.display()));
+        match self.try_online_activate(server_url, license_key, friendly_name) {
+            Ok(signed) => {
+                if let Ok(json) = serde_json::to_string_pretty(&signed) {
+                    let _ = std::fs::write(cache_path, json);
+                }
+                return self.verify_signed(&signed);
+            }
+            Err(LicenseError::Revoked) => {
+                log::warn!("License revoked by server - removing cached file");
+                if let Err(e) = std::fs::remove_file(cache_path) {
+                    if e.kind() != std::io::ErrorKind::NotFound {
+                        log::error!("Failed to remove cached license file: {}", e);
+                    }
+                }
+                return LicenseStatus::Revoked;
+            }
+            Err(LicenseError::NotFound) => {
+                log::warn!("License not found on server - removing cached file");
+                if let Err(e) = std::fs::remove_file(cache_path) {
+                    if e.kind() != std::io::ErrorKind::NotFound {
+                        log::error!("Failed to remove cached license file: {}", e);
+                    }
+                }
+                return LicenseStatus::InvalidLicenseKey;
+            }
+            Err(LicenseError::MachineLimitReached(max)) => {
+                log::warn!("Cannot activate license - machine limit reached");
+                return LicenseStatus::Error(format!("Machine limit reached: {}", max));
+            }
+            Err(e) => {
+                log::warn!("Online license refresh failed, using cached file: {}", e);
+            }
+        }
+        
+        if !cache_path.exists() {
+            return LicenseStatus::Error(format!("Online license check failed, cached license file cannot be found: {}", cache_path.display()));
         }
 
         // Fall back to local file
-        self.verify_file(path)
+        self.verify_file(cache_path)
     }
 
     fn try_online_activate(
@@ -303,6 +329,10 @@ impl LicenseClient {
     /// Verify a license from a connected USB hardware token.
     /// Scans all connected USB mass storage devices for a valid token.
     pub fn verify_token(&self) -> LicenseStatus {
+        if !self.allowed_license_methods.contains(&LicenseMethod::Token) {
+            return LicenseStatus::LicenseMethodNotAllowed("Token-based license check is not allowed by properties.".into());
+        }
+        
         let devices = match susi_core::usb::enumerate_usb_devices() {
             Ok(d) => d,
             Err(e) => return LicenseStatus::Error(format!("USB enumeration failed: {}", e)),
@@ -350,6 +380,10 @@ impl LicenseClient {
     pub fn get_machine_code() -> Result<String, LicenseError> {
         fingerprint::get_machine_code()
     }
+
+    pub fn get_allowed_license_methods(&self) -> Vec<LicenseMethod> {
+        self.allowed_license_methods.clone()
+    }
 }
 
 #[cfg(test)]
@@ -357,6 +391,7 @@ mod tests {
     use super::*;
     use chrono::Duration;
     use susi_core::crypto::{generate_keypair, private_key_to_pem, public_key_to_pem, sign_license};
+    use susi_core::properties::{sign_properties, LicenseMethod, LicenseProperties};
 
     fn make_keypair_pems() -> (String, String, rsa::RsaPrivateKey) {
         let (private, public) = generate_keypair(2048).unwrap();
@@ -567,5 +602,139 @@ mod tests {
         assert!(!status.has_feature("anything"));
         assert!(status.features().is_empty());
         assert!(status.expires().is_none());
+    }
+
+    fn unique_tmp(name: &str) -> std::path::PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("{}_{}_{}", name, std::process::id(), nanos))
+    }
+
+    fn write_signed_license(
+        private: &rsa::RsaPrivateKey,
+        payload: &LicensePayload,
+        path: &Path,
+    ) {
+        let signed = sign_license(private, payload).unwrap();
+        let json = serde_json::to_string_pretty(&signed).unwrap();
+        std::fs::write(path, &json).unwrap();
+    }
+
+    fn write_props(private: &rsa::RsaPrivateKey, props: &LicenseProperties, path: &Path) {
+        let signed = sign_properties(private, props).unwrap();
+        std::fs::write(path, serde_json::to_string(&signed).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn test_verify_with_properties_file_method_success() {
+        let (_, pub_pem, private) = make_keypair_pems();
+        let license_path = unique_tmp("props_file_license.json");
+        let props_path = unique_tmp("props_file_props.json");
+        write_signed_license(&private, &make_valid_payload(None), &license_path);
+
+        let props = LicenseProperties { methods: vec![LicenseMethod::File] };
+        write_props(&private, &props, &props_path);
+
+        let client = LicenseClient::from_properties(&pub_pem, &props_path).unwrap();
+        let status = client.verify_file(&license_path);
+        assert!(status.is_valid(), "expected valid, got {:?}", status);
+        assert!(status.has_feature("full_fusion"));
+
+        let _ = std::fs::remove_file(&license_path);
+        let _ = std::fs::remove_file(&props_path);
+    }
+
+    #[test]
+    fn test_verify_with_properties_invalid_signature() {
+        let (_, pub_pem, _) = make_keypair_pems();
+        let (_, _, other_private) = make_keypair_pems();
+
+        let props_path = unique_tmp("props_bad_sig.json");
+        let props = LicenseProperties { methods: vec![LicenseMethod::Token] };
+        write_props(&other_private, &props, &props_path);
+
+        let err = LicenseClient::from_properties(&pub_pem, &props_path);
+        assert!(err.is_err(), "expected Err for wrong signing key");
+
+        let _ = std::fs::remove_file(&props_path);
+    }
+
+    #[test]
+    fn test_verify_with_properties_tampered_data() {
+        let (_, pub_pem, private) = make_keypair_pems();
+        let props_path = unique_tmp("props_tampered.json");
+
+        let props = LicenseProperties { methods: vec![LicenseMethod::File] };
+        let mut signed = sign_properties(&private, &props).unwrap();
+        signed.properties_data = signed.properties_data.replace("file", "token");
+        std::fs::write(&props_path, serde_json::to_string(&signed).unwrap()).unwrap();
+
+        let err = LicenseClient::from_properties(&pub_pem, &props_path);
+        assert!(err.is_err(), "expected Err for tampered data");
+
+        let _ = std::fs::remove_file(&props_path);
+    }
+
+    #[test]
+    fn test_verify_with_properties_missing_file() {
+        let (_, pub_pem, _) = make_keypair_pems();
+        let err = LicenseClient::from_properties(&pub_pem, Path::new("/does/not/exist/susi-properties.json"));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_verify_with_properties_malformed_bytes() {
+        let (_, pub_pem, _) = make_keypair_pems();
+        let props_path = unique_tmp("props_malformed.json");
+        std::fs::write(&props_path, b"not a susi properties file").unwrap();
+
+        let err = LicenseClient::from_properties(&pub_pem, &props_path);
+        assert!(err.is_err());
+
+        let _ = std::fs::remove_file(&props_path);
+    }
+
+    #[test]
+    fn test_verify_with_properties_empty_methods() {
+        let (_, pub_pem, private) = make_keypair_pems();
+        let props_path = unique_tmp("props_empty.json");
+        let props = LicenseProperties { methods: vec![] };
+        write_props(&private, &props, &props_path);
+
+        let client = LicenseClient::from_properties(&pub_pem, &props_path).unwrap();
+        // No methods allowed
+        let status = client.verify_file(Path::new("/tmp/any.json"));
+        assert!(matches!(status, LicenseStatus::LicenseMethodNotAllowed(_)));
+        let status = client.verify_token();
+        assert!(matches!(status, LicenseStatus::LicenseMethodNotAllowed(_)));
+        let status = client.verify_and_refresh(Path::new("/tmp/missing.json"), "AAAA-BBBB-CCCC-DDDD", None);
+        assert!(matches!(status, LicenseStatus::LicenseMethodNotAllowed(_)));
+
+        let _ = std::fs::remove_file(&props_path);
+    }
+
+    #[test]
+    fn test_verify_with_properties_only_allowed() {
+        // Properties listing only File: verify_file allowed, verify_token blocked.
+        let (_, pub_pem, private) = make_keypair_pems();
+        let props_path = unique_tmp("props_order.json");
+        let props = LicenseProperties { methods: vec![LicenseMethod::File] };
+        write_props(&private, &props, &props_path);
+
+        let client = LicenseClient::from_properties(&pub_pem, &props_path).unwrap();
+        // File method allowed
+        let status = client.verify_file(Path::new("/tmp/missing.json"));
+        assert!(matches!(status, LicenseStatus::FileNotFound(_)));
+        // Token method not allowed
+        let status = client.verify_token();
+        assert!(matches!(status, LicenseStatus::LicenseMethodNotAllowed(_)));
+        // Server method not allowed
+        let status = client.verify_and_refresh(Path::new("/tmp/missing.json"), "AAAA-BBBB-CCCC-DDDD", None);
+        assert!(matches!(status, LicenseStatus::LicenseMethodNotAllowed(_)));
+        
+        let _ = std::fs::remove_file(&props_path);
     }
 }

--- a/crates/susi_core/src/error.rs
+++ b/crates/susi_core/src/error.rs
@@ -50,6 +50,9 @@ pub enum LicenseError {
     #[error("Token decryption failed: {0}")]
     TokenDecryptionFailed(String),
 
+    #[error("Invalid license properties: {0}")]
+    InvalidProperties(String),
+
     #[error("{0}")]
     Other(String),
 }

--- a/crates/susi_core/src/lib.rs
+++ b/crates/susi_core/src/lib.rs
@@ -5,10 +5,14 @@ pub mod error;
 pub mod features;
 pub mod fingerprint;
 pub mod license;
+pub mod properties;
 pub mod token;
 pub mod usb;
 
 pub use crypto::{generate_keypair, sign_license, verify_license};
+pub use properties::{
+    sign_properties, verify_properties, LicenseMethod, LicenseProperties,
+};
 pub use error::LicenseError;
 pub use fingerprint::get_machine_code;
 pub use license::{

--- a/crates/susi_core/src/properties.rs
+++ b/crates/susi_core/src/properties.rs
@@ -15,11 +15,9 @@ use crate::error::LicenseError;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum LicenseMethod {
-    File, 
+    File,
     Token,
-    Server {
-        url: String
-    },
+    Server,
 }
 
 /// Client-side licensing properties. Specifies which licensing methods
@@ -29,7 +27,8 @@ pub enum LicenseMethod {
 /// verified.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LicenseProperties {
-    pub methods: Vec<LicenseMethod>
+    pub server_url: String,
+    pub methods: Vec<LicenseMethod>,
 }
 
 /// A signed license properties that can be written to disk
@@ -73,6 +72,13 @@ pub fn verify_properties(
         .map_err(|_| LicenseError::InvalidSignature)?;
 
     let payload: LicenseProperties = serde_json::from_str(&signed.properties_data)?;
+
+    if payload.methods.is_empty() {
+        return Err(LicenseError::InvalidProperties("At least one license method must be specified".to_string()));
+    } else if (1..payload.methods.len()).any(|i| payload.methods[i..].contains(&payload.methods[i - 1])) {
+        return Err(LicenseError::InvalidProperties("Duplicate license methods are not allowed".to_string()));
+    }
+
     Ok(payload)
 }
 
@@ -83,8 +89,9 @@ mod tests {
 
     fn sample_properties() -> LicenseProperties {
         LicenseProperties {
+            server_url: "https://license.example.com".to_string(),
             methods: vec![
-                LicenseMethod::Server { url: "https://license.example.com".to_string() },
+                LicenseMethod::Server,
                 LicenseMethod::File,
                 LicenseMethod::Token,
             ],
@@ -154,11 +161,18 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_methods_roundtrips() {
+    fn test_empty_methods_is_rejected() {
         let (priv_key, pub_key) = generate_keypair(2048).unwrap();
-        let props = LicenseProperties { methods: vec![] };
+        let props = LicenseProperties { server_url: "https://license.example.com".to_string(), methods: vec![] };
         let signed = sign_properties(&priv_key, &props).unwrap();
-        let verified = verify_properties(&pub_key, &signed).unwrap();
-        assert_eq!(verified.methods.len(), 0);
+        assert!(verify_properties(&pub_key, &signed).is_err());
+    }
+
+    #[test]
+    fn test_duplicate_methods_is_rejected() {
+        let (priv_key, pub_key) = generate_keypair(2048).unwrap();
+        let props = LicenseProperties { server_url: "https://license.example.com".to_string(), methods: vec![LicenseMethod::File, LicenseMethod::Token, LicenseMethod::File] };
+        let signed = sign_properties(&priv_key, &props).unwrap();
+        assert!(verify_properties(&pub_key, &signed).is_err());
     }
 }

--- a/crates/susi_core/src/properties.rs
+++ b/crates/susi_core/src/properties.rs
@@ -1,0 +1,164 @@
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use rsa::sha2::Sha256;
+use rsa::signature::{SignatureEncoding, Signer, Verifier};
+use rsa::{
+    pkcs1v15::{SigningKey, VerifyingKey},
+    RsaPrivateKey, RsaPublicKey,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::error::LicenseError;
+
+/// A licensing method that the client may use to verify a license.
+/// The order in which methods appear in [`LicenseProperties::methods`] defines
+/// the order in which they are tried.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum LicenseMethod {
+    File, 
+    Token,
+    Server {
+        url: String
+    },
+}
+
+/// Client-side licensing properties. Specifies which licensing methods
+/// to attempt (in order) and any admin-controlled parameters (server URL,
+/// cache path, local license file path). Runtime-specific parameters
+/// (license key, friendly name) are supplied when the properties are
+/// verified.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LicenseProperties {
+    pub methods: Vec<LicenseMethod>
+}
+
+/// A signed license properties that can be written to disk
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignedLicenseProperties {
+    /// JSON-serialized LicenseProperties (canonical form).
+    pub properties_data: String,
+    /// Base64-encoded RSA-SHA256 signature of `properties_data`.
+    pub signature: String,
+}
+
+/// Sign a [`LicenseProperties`] with the admin's private key and return the susi-properties.json
+pub fn sign_properties(
+    private_key: &RsaPrivateKey,
+    properties: &LicenseProperties,
+) -> Result<SignedLicenseProperties, LicenseError> {
+     let properties_data = serde_json::to_string(properties)?;
+    let signing_key = SigningKey::<Sha256>::new(private_key.clone());
+    let signature = signing_key.sign(properties_data.as_bytes());
+    let signature_b64 = BASE64.encode(signature.to_bytes());
+
+    Ok(SignedLicenseProperties {
+        properties_data,
+        signature: signature_b64,
+    })
+}
+
+/// Verify a binary signed `susi-properties.json` with the public key and
+/// return the underlying [`LicenseProperties`].
+pub fn verify_properties(
+    public_key: &RsaPublicKey,
+    signed: &SignedLicenseProperties,
+) -> Result<LicenseProperties, LicenseError> {
+    let signature_bytes = BASE64.decode(&signed.signature)?;
+    let verifying_key = VerifyingKey::<Sha256>::new(public_key.clone());
+    let signature = rsa::pkcs1v15::Signature::try_from(signature_bytes.as_slice())
+        .map_err(|_| LicenseError::InvalidSignature)?;
+
+    verifying_key
+        .verify(signed.properties_data.as_bytes(), &signature)
+        .map_err(|_| LicenseError::InvalidSignature)?;
+
+    let payload: LicenseProperties = serde_json::from_str(&signed.properties_data)?;
+    Ok(payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::generate_keypair;
+
+    fn sample_properties() -> LicenseProperties {
+        LicenseProperties {
+            methods: vec![
+                LicenseMethod::Server { url: "https://license.example.com".to_string() },
+                LicenseMethod::File,
+                LicenseMethod::Token,
+            ],
+        }
+    }
+
+    #[test]
+    fn test_sign_verify_roundtrip() {
+        let (priv_key, pub_key) = generate_keypair(2048).unwrap();
+        let properties = sample_properties();
+        let signed = sign_properties(&priv_key, &properties).unwrap();
+        let verified = verify_properties(&pub_key, &signed).unwrap();
+        assert_eq!(verified, properties);
+    }
+
+    #[test]
+    fn test_tampered_payload_fails_verification() {
+        let (priv_key, pub_key) = generate_keypair(2048).unwrap();
+        let mut signed = sign_properties(&priv_key, &sample_properties()).unwrap();
+        signed.properties_data = signed.properties_data.replace("license.example.com", "attacker.example.com");
+        let err = verify_properties(&pub_key, &signed);
+        assert!(matches!(err, Err(LicenseError::InvalidSignature)));
+    }
+
+    #[test]
+    fn test_tampered_signature_fails_verification() {
+        let (priv_key, pub_key) = generate_keypair(2048).unwrap();
+        let mut signed = sign_properties(&priv_key, &sample_properties()).unwrap();
+        let first = signed.signature.chars().next().unwrap();
+        let replacement = if first == 'A' { 'B' } else { 'A' };
+        signed.signature = replacement.to_string() + &signed.signature[1..];
+        let err = verify_properties(&pub_key, &signed);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_wrong_key_fails_verification() {
+        let (priv_key, _) = generate_keypair(2048).unwrap();
+        let (_, wrong_pub) = generate_keypair(2048).unwrap();
+        let signed = sign_properties(&priv_key, &sample_properties()).unwrap();
+        let err = verify_properties(&wrong_pub, &signed);
+        assert!(matches!(err, Err(LicenseError::InvalidSignature)));
+    }
+
+    #[test]
+    fn test_invalid_json_is_rejected() {
+        let (priv_key, pub_key) = generate_keypair(2048).unwrap();
+        let mut signed = sign_properties(&priv_key, &sample_properties()).unwrap();
+        signed.properties_data = "not valid json".to_string();
+        assert!(verify_properties(&pub_key, &signed).is_err());
+    }
+
+    #[test]
+    fn test_invalid_base64_signature_is_rejected() {
+        let (priv_key, pub_key) = generate_keypair(2048).unwrap();
+        let mut signed = sign_properties(&priv_key, &sample_properties()).unwrap();
+        signed.signature = "!!!not-base64!!!".to_string();
+        assert!(verify_properties(&pub_key, &signed).is_err());
+    }
+
+    #[test]
+    fn test_invalid_no_signature_is_rejected() {
+        let (priv_key, pub_key) = generate_keypair(2048).unwrap();
+        let mut signed = sign_properties(&priv_key, &sample_properties()).unwrap();
+        signed.signature = String::new();
+        assert!(verify_properties(&pub_key, &signed).is_err());
+    }
+
+    #[test]
+    fn test_empty_methods_roundtrips() {
+        let (priv_key, pub_key) = generate_keypair(2048).unwrap();
+        let props = LicenseProperties { methods: vec![] };
+        let signed = sign_properties(&priv_key, &props).unwrap();
+        let verified = verify_properties(&pub_key, &signed).unwrap();
+        assert_eq!(verified.methods.len(), 0);
+    }
+}

--- a/crates/susi_server/src/dashboard.html
+++ b/crates/susi_server/src/dashboard.html
@@ -81,6 +81,7 @@ button.secondary {
 button.secondary:hover { background: var(--border); }
 button.danger { background: var(--red); }
 button.danger:hover { background: #ef4444; }
+button:disabled { opacity: 0.4; cursor: not-allowed; }
 button.small { padding: 4px 10px; font-size: 12px; }
 
 input, select {
@@ -378,6 +379,7 @@ tr:hover td { background: rgba(108, 140, 255, 0.04); }
     <h1>Susi Server</h1>
     <div class="header-actions">
         <span id="connectionStatus" class="status">Connecting...</span>
+        <button id="btnExportProperties" class="small secondary" onclick="showPropertiesModal()" style="display:none;">Export Properties</button>
         <button id="btnUsers" class="small secondary" onclick="showUsersModal()" style="display:none;">Users</button>
         <button id="btn2FA" class="small secondary" onclick="show2FAModal()" style="display:none;">2FA</button>
         <span id="currentUser" style="display:none;font-size:13px;color:var(--text2);"></span>
@@ -779,6 +781,25 @@ tr:hover td { background: rgba(108, 140, 255, 0.04); }
     </div>
 </div>
 
+<!-- Export Properties Modal -->
+<div id="propertiesModal" class="modal-overlay" onclick="if(event.target===this)closePropertiesModal()">
+    <div class="modal">
+        <h2>Export Properties File</h2>
+        <p style="font-size:13px;color:var(--text2);margin-bottom:16px;">Configure which licensing methods are allowed for clients. The order defines the priority in which methods are tried.</p>
+        <div id="propertiesMethodList" style="display:flex;flex-direction:column;gap:10px;margin-bottom:16px;">
+        </div>
+        <div style="display:flex;gap:8px;margin-bottom:16px;">
+            <button id="btnAddFile" class="small secondary" onclick="addPropertyMethod('file')" style="min-width:auto;">+ File</button>
+            <button id="btnAddToken" class="small secondary" onclick="addPropertyMethod('token')" style="min-width:auto;">+ Token</button>
+            <button id="btnAddServer" class="small secondary" onclick="addPropertyMethod('server')" style="min-width:auto;">+ Server</button>
+        </div>
+        <div class="form-actions">
+            <button class="secondary" onclick="closePropertiesModal()">Cancel</button>
+            <button onclick="doExportProperties()">Export &amp; Download</button>
+        </div>
+    </div>
+</div>
+
 <script>
 const API = '/api/v1';
 let authToken = '';
@@ -808,6 +829,7 @@ function showLogin() {
     document.getElementById('btnLogout').style.display = 'none';
     document.getElementById('btn2FA').style.display = 'none';
     document.getElementById('btnUsers').style.display = 'none';
+    document.getElementById('btnExportProperties').style.display = 'none';
     document.getElementById('currentUser').style.display = 'none';
     setTimeout(() => document.getElementById('loginUsername').focus(), 50);
 }
@@ -941,6 +963,7 @@ function enterDashboard() {
 
     const isAdmin = userRole === 'admin';
     document.getElementById('btnUsers').style.display = isAdmin ? '' : 'none';
+    document.getElementById('btnExportProperties').style.display = isAdmin ? '' : 'none';
     document.getElementById('adminLicenseToolbar').style.display = isAdmin ? '' : 'none';
     document.getElementById('detailPanel').classList.remove('visible');
     document.getElementById('adminLicenseTableSection').style.display = isAdmin ? '' : 'none';
@@ -1386,6 +1409,110 @@ async function doExport() {
         closeExportModal();
         await loadLicenses();
         selectLicense(key);
+    } catch (e) {
+        toast('Failed: ' + e.message, 'error');
+    }
+}
+
+// Properties export
+let propertiesMethods = [];
+
+function showPropertiesModal() {
+    propertiesMethods = [
+        { type: 'server', url: window.location.origin + '/api/v1' },
+        { type: 'file' },
+        { type: 'token' },
+    ];
+    renderPropertiesMethods();
+    document.getElementById('propertiesModal').classList.add('visible');
+}
+
+function closePropertiesModal() {
+    document.getElementById('propertiesModal').classList.remove('visible');
+}
+
+function renderPropertiesMethods() {
+    const list = document.getElementById('propertiesMethodList');
+    const has = t => propertiesMethods.some(m => m.type === t);
+    document.getElementById('btnAddFile').disabled = has('file');
+    document.getElementById('btnAddToken').disabled = has('token');
+    document.getElementById('btnAddServer').disabled = has('server');
+    if (propertiesMethods.length === 0) {
+        list.innerHTML = '<div style="font-size:13px;color:var(--text2);font-style:italic;">No methods added. Use the buttons below to add methods.</div>';
+        return;
+    }
+    list.innerHTML = propertiesMethods.map((m, i) => {
+        const upBtn = i > 0 ? `<button class="small secondary" onclick="movePropertyMethod(${i},-1)" style="min-width:auto;padding:4px 8px;" title="Move up">\u2191</button>` : '';
+        const downBtn = i < propertiesMethods.length - 1 ? `<button class="small secondary" onclick="movePropertyMethod(${i},1)" style="min-width:auto;padding:4px 8px;" title="Move down">\u2193</button>` : '';
+        const removeBtn = `<button class="small secondary" onclick="removePropertyMethod(${i})" style="min-width:auto;padding:4px 8px;color:var(--red);" title="Remove">\u2715</button>`;
+        let label = m.type.charAt(0).toUpperCase() + m.type.slice(1);
+        let extra = '';
+        if (m.type === 'server') {
+            extra = `<input type="text" value="${m.url || ''}" onchange="propertiesMethods[${i}].url=this.value" placeholder="https://license.example.com" style="flex:1;margin-left:8px;">`;
+        }
+        return `<div style="display:flex;align-items:center;gap:6px;background:var(--bg3);padding:8px 12px;border-radius:var(--radius);border:1px solid var(--border);">
+            <span style="font-size:13px;font-weight:500;min-width:55px;">${label}</span>${extra}
+            <span style="flex:${m.type === 'server' ? '0' : '1'};"></span>
+            ${upBtn}${downBtn}${removeBtn}
+        </div>`;
+    }).join('');
+}
+
+function addPropertyMethod(type) {
+    if (propertiesMethods.some(m => m.type === type)) {
+        toast('Method "' + type + '" is already added', 'error');
+        return;
+    }
+    if (type === 'server') {
+        propertiesMethods.push({ type: 'server', url: window.location.origin + '/api/v1' });
+    } else {
+        propertiesMethods.push({ type });
+    }
+    renderPropertiesMethods();
+}
+
+function removePropertyMethod(i) {
+    propertiesMethods.splice(i, 1);
+    renderPropertiesMethods();
+}
+
+function movePropertyMethod(i, dir) {
+    const j = i + dir;
+    [propertiesMethods[i], propertiesMethods[j]] = [propertiesMethods[j], propertiesMethods[i]];
+    renderPropertiesMethods();
+}
+
+async function doExportProperties() {
+    if (propertiesMethods.length === 0) {
+        toast('Add at least one licensing method', 'error');
+        return;
+    }
+    for (const m of propertiesMethods) {
+        if (m.type === 'server' && !m.url.trim()) {
+            toast('Server URL cannot be empty', 'error');
+            return;
+        }
+    }
+    try {
+        const resp = await fetch(API + '/properties/export', {
+            method: 'POST',
+            headers: authHeaders(),
+            body: JSON.stringify({ methods: propertiesMethods }),
+        });
+        if (!resp.ok) {
+            const err = await resp.json();
+            toast('Error: ' + err.error, 'error');
+            return;
+        }
+        const blob = await resp.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'susi-properties.json';
+        a.click();
+        URL.revokeObjectURL(url);
+        toast('Properties file exported', 'success');
+        closePropertiesModal();
     } catch (e) {
         toast('Failed: ' + e.message, 'error');
     }

--- a/crates/susi_server/src/dashboard.html
+++ b/crates/susi_server/src/dashboard.html
@@ -786,6 +786,10 @@ tr:hover td { background: rgba(108, 140, 255, 0.04); }
     <div class="modal">
         <h2>Export Properties File</h2>
         <p style="font-size:13px;color:var(--text2);margin-bottom:16px;">Configure which licensing methods are allowed for clients. The order defines the priority in which methods are tried.</p>
+        <div id="propertiesServerUrlRow" style="margin-bottom:16px;">
+            <label style="font-size:13px;font-weight:500;display:block;margin-bottom:4px;">Server URL</label>
+            <input type="text" id="propertiesServerUrl" placeholder="https://license.example.com/api/v1" style="width:100%;">
+        </div>
         <div id="propertiesMethodList" style="display:flex;flex-direction:column;gap:10px;margin-bottom:16px;">
         </div>
         <div style="display:flex;gap:8px;margin-bottom:16px;">
@@ -1419,10 +1423,11 @@ let propertiesMethods = [];
 
 function showPropertiesModal() {
     propertiesMethods = [
-        { type: 'server', url: window.location.origin + '/api/v1' },
+        { type: 'server' },
         { type: 'file' },
         { type: 'token' },
     ];
+    document.getElementById('propertiesServerUrl').value = window.location.origin + '/api/v1';
     renderPropertiesMethods();
     document.getElementById('propertiesModal').classList.add('visible');
 }
@@ -1446,13 +1451,9 @@ function renderPropertiesMethods() {
         const downBtn = i < propertiesMethods.length - 1 ? `<button class="small secondary" onclick="movePropertyMethod(${i},1)" style="min-width:auto;padding:4px 8px;" title="Move down">\u2193</button>` : '';
         const removeBtn = `<button class="small secondary" onclick="removePropertyMethod(${i})" style="min-width:auto;padding:4px 8px;color:var(--red);" title="Remove">\u2715</button>`;
         let label = m.type.charAt(0).toUpperCase() + m.type.slice(1);
-        let extra = '';
-        if (m.type === 'server') {
-            extra = `<input type="text" value="${m.url || ''}" onchange="propertiesMethods[${i}].url=this.value" placeholder="https://license.example.com" style="flex:1;margin-left:8px;">`;
-        }
         return `<div style="display:flex;align-items:center;gap:6px;background:var(--bg3);padding:8px 12px;border-radius:var(--radius);border:1px solid var(--border);">
-            <span style="font-size:13px;font-weight:500;min-width:55px;">${label}</span>${extra}
-            <span style="flex:${m.type === 'server' ? '0' : '1'};"></span>
+            <span style="font-size:13px;font-weight:500;min-width:55px;">${label}</span>
+            <span style="flex:1;"></span>
             ${upBtn}${downBtn}${removeBtn}
         </div>`;
     }).join('');
@@ -1463,11 +1464,7 @@ function addPropertyMethod(type) {
         toast('Method "' + type + '" is already added', 'error');
         return;
     }
-    if (type === 'server') {
-        propertiesMethods.push({ type: 'server', url: window.location.origin + '/api/v1' });
-    } else {
-        propertiesMethods.push({ type });
-    }
+    propertiesMethods.push({ type });
     renderPropertiesMethods();
 }
 
@@ -1487,17 +1484,17 @@ async function doExportProperties() {
         toast('Add at least one licensing method', 'error');
         return;
     }
-    for (const m of propertiesMethods) {
-        if (m.type === 'server' && !m.url.trim()) {
-            toast('Server URL cannot be empty', 'error');
-            return;
-        }
+    const serverUrl = document.getElementById('propertiesServerUrl').value.trim();
+    if (!serverUrl) {
+        toast('Server URL is required', 'error');
+        return;
     }
+    const body = { server_url: serverUrl, methods: propertiesMethods };
     try {
         const resp = await fetch(API + '/properties/export', {
             method: 'POST',
             headers: authHeaders(),
-            body: JSON.stringify({ methods: propertiesMethods }),
+            body: JSON.stringify(body),
         });
         if (!resp.ok) {
             const err = await resp.json();

--- a/crates/susi_server/src/main.rs
+++ b/crates/susi_server/src/main.rs
@@ -142,6 +142,7 @@ struct ExportRequest {
 
 #[derive(Deserialize)]
 struct PropertiesExportRequest {
+    server_url: String,
     methods: Vec<PropertiesMethodEntry>,
 }
 
@@ -150,7 +151,7 @@ struct PropertiesExportRequest {
 enum PropertiesMethodEntry {
     File,
     Token,
-    Server { url: String },
+    Server,
 }
 
 #[derive(Serialize)]
@@ -954,10 +955,14 @@ async fn handle_export_properties(
     let methods: Vec<LicenseMethod> = req.methods.into_iter().map(|m| match m {
         PropertiesMethodEntry::File => LicenseMethod::File,
         PropertiesMethodEntry::Token => LicenseMethod::Token,
-        PropertiesMethodEntry::Server { url } => LicenseMethod::Server { url },
+        PropertiesMethodEntry::Server => LicenseMethod::Server,
     }).collect();
 
-    let properties = LicenseProperties { methods };
+    if req.server_url.is_empty() {
+        return Err(error_response(StatusCode::BAD_REQUEST, "server_url is required"));
+    }
+
+    let properties = LicenseProperties { server_url: req.server_url, methods };
     let signed = sign_properties(&state.private_key, &properties)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
 

--- a/crates/susi_server/src/main.rs
+++ b/crates/susi_server/src/main.rs
@@ -15,6 +15,7 @@ use clap::Parser;
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use rand::Rng;
 use susi_core::crypto::{private_key_from_pem, sign_license};
+use susi_core::properties::{sign_properties, LicenseMethod, LicenseProperties};
 use susi_core::db::LicenseDb;
 use susi_core::{License, DEFAULT_LEASE_DURATION_HOURS, DEFAULT_LEASE_GRACE_HOURS};
 use rsa::RsaPrivateKey;
@@ -137,6 +138,19 @@ struct ExportRequest {
     machine_code: String,
     #[serde(default)]
     friendly_name: String,
+}
+
+#[derive(Deserialize)]
+struct PropertiesExportRequest {
+    methods: Vec<PropertiesMethodEntry>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum PropertiesMethodEntry {
+    File,
+    Token,
+    Server { url: String },
 }
 
 #[derive(Serialize)]
@@ -918,6 +932,45 @@ async fn handle_export_license(
             (
                 header::CONTENT_DISPOSITION,
                 "attachment; filename=\"license.json\"",
+            ),
+        ],
+        json,
+    ))
+}
+
+async fn handle_export_properties(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(req): Json<PropertiesExportRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    let claims = validate_jwt(&headers, &state.jwt_secret)?;
+    require_password_changed(&state, &claims.sub)?;
+    require_admin(&state, &claims.sub)?;
+
+    if req.methods.is_empty() {
+        return Err(error_response(StatusCode::BAD_REQUEST, "At least one method is required"));
+    }
+
+    let methods: Vec<LicenseMethod> = req.methods.into_iter().map(|m| match m {
+        PropertiesMethodEntry::File => LicenseMethod::File,
+        PropertiesMethodEntry::Token => LicenseMethod::Token,
+        PropertiesMethodEntry::Server { url } => LicenseMethod::Server { url },
+    }).collect();
+
+    let properties = LicenseProperties { methods };
+    let signed = sign_properties(&state.private_key, &properties)
+        .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
+
+    let json = serde_json::to_string_pretty(&signed)
+        .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
+
+    Ok((
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "application/json"),
+            (
+                header::CONTENT_DISPOSITION,
+                "attachment; filename=\"susi-properties.json\"",
             ),
         ],
         json,
@@ -1882,6 +1935,8 @@ async fn main() -> Result<()> {
                 .layer(DefaultBodyLimit::max(500 * 1024 * 1024))
         )
         .route("/api/v1/releases/{tag}", axum::routing::delete(handle_delete_release))
+        // Properties export (JWT protected, admin only)
+        .route("/api/v1/properties/export", post(handle_export_properties))
         // Workspace endpoints (JWT protected)
         .route("/api/v1/workspaces", get(handle_list_workspaces).post(handle_create_workspace))
         .route("/api/v1/workspaces/{id}", get(handle_get_workspace).put(handle_update_workspace).delete(handle_delete_workspace))


### PR DESCRIPTION
This PR add a new feature called license properties. This is a new file (e.g. susi-properties.json) which defines which license methods are allowed and for the case of online verification also contains the server url. This file is signed using the private key to make it tamper-proof. Using this new feature the application, which should be protected by susi, can make the licensing dependend on the contents of the properties file and thus change it without chaning code or making a release.

A new constructor has been added to both susi clients which take a path to a susi-properties files. This client then only allows the verification it contains.

Property files can either be created using the command line `./susi-admin.exe properties` or the web interface.