### PR TITLE
Add UI to export license tokens end end-user CLI to list device fingerprint and USB serial numbers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/susi_client",
     "crates/susi_admin",
     "crates/susi_server",
+    "crates/susi_helper",
 ]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
 | `susi_client` | Library | Verification library + workspace/release/docs HTTP client (sync + async APIs) |
 | `susi_admin` | Binary | CLI tool for key generation, license creation, and management |
 | `susi_server` | Binary | HTTP server with SQLite backend — licensing, releases, docs, website, shop, contact |
+| `susi_helper` | Binary | End-user utility for retrieving machine fingerprints and USB serial numbers |
 | `cpp/` | C++ Library | Standalone verification client for C++ applications |
 
 `susi_server` is split into one module per surface area (`docs.rs`, `website.rs`, `shop.rs`, `contact.rs`, `email.rs`, `invoice_pdf.rs` plus the licensing/auth core in `main.rs`) so each feature can be reasoned about independently.
@@ -317,8 +318,10 @@ Machine identity is computed differently depending on the operating system:
 These values are combined and hashed with SHA-256 to produce a stable fingerprint. Print the current machine's fingerprint with:
 
 ```bash
-susi-admin fingerprint
+susi-helper fingerprint
 ```
+
+> Admins can also use `susi-admin fingerprint`, but `susi-helper` is the lightweight tool intended for end users.
 
 ## USB Hardware Tokens
 
@@ -393,6 +396,29 @@ The `.susi/license.bin` file on the USB stick contains:
 | 12+N | 16 bytes | AES-GCM authentication tag |
 
 The encryption key is derived as: `HKDF-SHA256(ikm=usb_serial, salt="susi-token-v1", info="license-encryption")`.
+
+## Susi Helper
+
+`susi-helper` is a small end-user utility that helps customers provide the information needed to activate a license. It requires no database or private key — it is safe to ship to end users alongside your product.
+
+```bash
+# Print the hardware fingerprint of the current machine
+# (paste this into the dashboard's "Machine Code" field when exporting a license)
+susi-helper fingerprint
+
+# List all connected USB drives and their serial numbers
+# (use the serial shown here when exporting a USB token license)
+susi-helper list-usb-serials
+```
+
+Example output of `list-usb-serials`:
+
+```
+NAME              SERIAL
+----------------  ------------
+My USB Drive      ABC123DEF456
+Backup Stick      XYZ789000000
+```
 
 ## Server
 
@@ -994,6 +1020,7 @@ cargo build --workspace --release
 Binaries are output to `target/release/`:
 - `susi-admin` — CLI management tool
 - `susi-server` — HTTP activation server
+- `susi-helper` — end-user utility for fingerprinting and USB serial lookup
 
 ## Testing
 

--- a/crates/susi_core/src/usb.rs
+++ b/crates/susi_core/src/usb.rs
@@ -219,7 +219,9 @@ fn platform_enumerate() -> Result<Vec<UsbDevice>, LicenseError> {
             Err(_) => continue,
         };
 
-        let mut ext_buf = [0u8; 512];
+        #[repr(C, align(4))]
+        struct AlignedBuf([u8; 512]);
+        let mut ext_buf = AlignedBuf([0u8; 512]);
         let mut br = 0u32;
         let ext_ok = unsafe {
             DeviceIoControl(
@@ -227,8 +229,8 @@ fn platform_enumerate() -> Result<Vec<UsbDevice>, LicenseError> {
                 IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS,
                 None,
                 0,
-                Some(ext_buf.as_mut_ptr() as *mut c_void),
-                ext_buf.len() as u32,
+                Some(ext_buf.0.as_mut_ptr() as *mut c_void),
+                ext_buf.0.len() as u32,
                 Some(&mut br),
                 None,
             )
@@ -240,11 +242,15 @@ fn platform_enumerate() -> Result<Vec<UsbDevice>, LicenseError> {
             continue;
         }
 
-        let vde = unsafe { &*(ext_buf.as_ptr() as *const VOLUME_DISK_EXTENTS) };
-        if vde.NumberOfDiskExtents < 1 {
+        let (num_extents, disk_number) = unsafe {
+            let vde = ext_buf.0.as_ptr() as *const VOLUME_DISK_EXTENTS;
+            let n = std::ptr::read_unaligned(std::ptr::addr_of!((*vde).NumberOfDiskExtents));
+            let d = std::ptr::read_unaligned(std::ptr::addr_of!((*vde).Extents[0].DiskNumber));
+            (n, d)
+        };
+        if num_extents < 1 {
             continue;
         }
-        let disk_number = vde.Extents[0].DiskNumber;
 
         let Some(serial) = (unsafe { usb_instance_serial_for_disk_number(disk_number) }) else {
             continue;

--- a/crates/susi_helper/Cargo.toml
+++ b/crates/susi_helper/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "susi_helper"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "susi-helper"
+path = "src/main.rs"
+
+[dependencies]
+susi_core = { path = "../susi_core" }
+anyhow = { workspace = true }
+clap = { workspace = true }

--- a/crates/susi_helper/src/main.rs
+++ b/crates/susi_helper/src/main.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use susi_core::fingerprint;
+use susi_core::usb;
+
+#[derive(Parser)]
+#[command(name = "susi-helper", about = "SUSI helper utilities")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Print the hardware fingerprint of this machine
+    Fingerprint,
+    /// List serial numbers of all connected USB drives
+    ListUsbSerials,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Fingerprint => {
+            let code = fingerprint::get_machine_code()?;
+            println!("Fingerprint of this machine:");
+            println!("{}", code);
+        }
+        Commands::ListUsbSerials => {
+            let devices = usb::enumerate_usb_devices()?;
+            if devices.is_empty() {
+                println!("No USB mass storage devices found.");
+            } else {
+                let name_w = devices.iter().map(|d| d.name.len()).max().unwrap_or(4).max(4);
+                let serial_w = devices.iter().map(|d| d.serial.len()).max().unwrap_or(6).max(6);
+                println!("{:<name_w$}  {:<serial_w$}", "NAME", "SERIAL");
+                println!("{:-<name_w$}  {:-<serial_w$}", "", "");
+                for dev in &devices {
+                    println!("{:<name_w$}  {:<serial_w$}", dev.name, dev.serial);
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/susi_server/src/dashboard.html
+++ b/crates/susi_server/src/dashboard.html
@@ -1344,6 +1344,9 @@ body:has(.modal-overlay.visible) { overflow: hidden; }
                 <label>Friendly Name</label>
                 <input type="text" id="exportFriendlyName" placeholder="e.g. Vehicle-ECU-1">
             </div>
+            <div id="exportTokenHint" class="form-row" style="display:none;font-size:12px;color:var(--text2);line-height:1.5">
+                Put the downloaded file on a USB drive in a folder called <code style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;background:var(--bg3);padding:1px 5px;border-radius:3px">.susi</code>. Make sure the file is called <code style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;background:var(--bg3);padding:1px 5px;border-radius:3px">license.bin</code>
+            </div>
             <div class="form-actions">
                 <button class="secondary" onclick="closeExportModal()">Cancel</button>
                 <button onclick="doExport()">Export &amp; Download</button>
@@ -2637,6 +2640,7 @@ function onExportTypeChange() {
     const isToken = document.querySelector('input[name="exportType"]:checked').value === 'token';
     document.getElementById('exportFileRow').style.display = isToken ? 'none' : '';
     document.getElementById('exportTokenRow').style.display = isToken ? '' : 'none';
+    document.getElementById('exportTokenHint').style.display = isToken ? '' : 'none';
     const fileLabel = document.getElementById('exportTypeFileLabel');
     const tokenLabel = document.getElementById('exportTypeTokenLabel');
     fileLabel.style.background = isToken ? 'transparent' : 'var(--accent)';

--- a/crates/susi_server/src/dashboard.html
+++ b/crates/susi_server/src/dashboard.html
@@ -1315,24 +1315,39 @@ body:has(.modal-overlay.visible) { overflow: hidden; }
 <!-- Export Modal -->
 <div id="exportModal" class="modal-overlay" onclick="if(event.target===this&&_overlayMouseDownOnSelf)closeExportModal()">
     <div class="modal">
-        <h2>Export Signed License File</h2>
+        <h2>Export License</h2>
         <div class="modal-body">
             <div class="form-row">
                 <label>License Key</label>
                 <input type="text" id="exportKey" readonly>
             </div>
             <div class="form-row">
+                <label>Export Type</label>
+                <div style="display:flex;background:var(--bg3);border:1px solid var(--border);border-radius:6px;padding:3px;gap:3px;width:100%">
+                    <label id="exportTypeFileLabel" style="flex:1;text-align:center;padding:6px 18px;border-radius:4px;cursor:pointer;font-size:13px;font-weight:500;transition:background .15s,color .15s;background:var(--accent);color:#fff">
+                        <input type="radio" name="exportType" value="file" checked onchange="onExportTypeChange()" style="display:none"> License File
+                    </label>
+                    <label id="exportTypeTokenLabel" style="flex:1;text-align:center;padding:6px 18px;border-radius:4px;cursor:pointer;font-size:13px;font-weight:500;transition:background .15s,color .15s;background:transparent;color:var(--text2)">
+                        <input type="radio" name="exportType" value="token" onchange="onExportTypeChange()" style="display:none"> USB Token
+                    </label>
+                </div>
+            </div>
+            <div id="exportFileRow" class="form-row">
                 <label>Machine Code (SHA256 fingerprint)</label>
                 <input type="text" id="exportMachineCode" placeholder="Paste machine fingerprint here">
+            </div>
+            <div id="exportTokenRow" class="form-row" style="display:none">
+                <label>USB Serial Number</label>
+                <input type="text" id="exportUsbSerial" placeholder="Paste usb serial number here">
             </div>
             <div class="form-row">
                 <label>Friendly Name</label>
                 <input type="text" id="exportFriendlyName" placeholder="e.g. Vehicle-ECU-1">
             </div>
-        </div>
-        <div class="form-actions">
-            <button class="secondary" onclick="closeExportModal()">Cancel</button>
-            <button onclick="doExport()">Export &amp; Download</button>
+            <div class="form-actions">
+                <button class="secondary" onclick="closeExportModal()">Cancel</button>
+                <button onclick="doExport()">Export &amp; Download</button>
+            </div>
         </div>
     </div>
 </div>
@@ -2606,7 +2621,10 @@ function exportLicense() {
     if (!selectedKey) return;
     document.getElementById('exportKey').value = selectedKey;
     document.getElementById('exportMachineCode').value = '';
+    document.getElementById('exportUsbSerial').value = '';
     document.getElementById('exportFriendlyName').value = '';
+    document.querySelector('input[name="exportType"][value="file"]').checked = true;
+    onExportTypeChange();
     document.getElementById('exportModal').classList.add('visible');
     document.getElementById('exportMachineCode').focus();
 }
@@ -2615,18 +2633,43 @@ function closeExportModal() {
     document.getElementById('exportModal').classList.remove('visible');
 }
 
+function onExportTypeChange() {
+    const isToken = document.querySelector('input[name="exportType"]:checked').value === 'token';
+    document.getElementById('exportFileRow').style.display = isToken ? 'none' : '';
+    document.getElementById('exportTokenRow').style.display = isToken ? '' : 'none';
+    const fileLabel = document.getElementById('exportTypeFileLabel');
+    const tokenLabel = document.getElementById('exportTypeTokenLabel');
+    fileLabel.style.background = isToken ? 'transparent' : 'var(--accent)';
+    fileLabel.style.color = isToken ? 'var(--text2)' : '#fff';
+    tokenLabel.style.background = isToken ? 'var(--accent)' : 'transparent';
+    tokenLabel.style.color = isToken ? '#fff' : 'var(--text2)';
+}
+
 async function doExport() {
     const key = document.getElementById('exportKey').value;
-    const machineCode = document.getElementById('exportMachineCode').value.trim();
     const friendlyName = document.getElementById('exportFriendlyName').value.trim();
+    const isToken = document.querySelector('input[name="exportType"]:checked').value === 'token';
 
-    if (!machineCode) { toast('Machine code is required', 'error'); return; }
+    let endpoint, body, filename;
+    if (isToken) {
+        const usbSerial = document.getElementById('exportUsbSerial').value.trim();
+        if (!usbSerial) { toast('USB serial number is required', 'error'); return; }
+        endpoint = '/licenses/' + encodeURIComponent(key) + '/export-token';
+        body = JSON.stringify({ usb_serial: usbSerial, friendly_name: friendlyName });
+        filename = 'license.bin';
+    } else {
+        const machineCode = document.getElementById('exportMachineCode').value.trim();
+        if (!machineCode) { toast('Machine code is required', 'error'); return; }
+        endpoint = '/licenses/' + encodeURIComponent(key) + '/export';
+        body = JSON.stringify({ machine_code: machineCode, friendly_name: friendlyName });
+        filename = 'license.json';
+    }
 
     try {
-        const resp = await fetch(API + '/licenses/' + encodeURIComponent(key) + '/export', {
+        const resp = await fetch(API + endpoint, {
             method: 'POST',
             headers: authHeaders(),
-            body: JSON.stringify({ machine_code: machineCode, friendly_name: friendlyName }),
+            body,
         });
         if (!resp.ok) {
             const err = await resp.json();
@@ -2637,11 +2680,11 @@ async function doExport() {
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = 'license.json';
+        a.download = filename;
         a.click();
         URL.revokeObjectURL(url);
 
-        toast('License file exported', 'success');
+        toast(isToken ? 'USB token file exported' : 'License file exported', 'success');
         closeExportModal();
         await loadLicenses();
         selectLicense(key);

--- a/crates/susi_server/src/main.rs
+++ b/crates/susi_server/src/main.rs
@@ -2030,8 +2030,7 @@ async fn handle_export_token(
     Json(req): Json<ExportTokenRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
     let principal = validate_principal(&headers, &state)?;
-    require_password_changed(&state, &principal)?;
-    require_admin(&state, &principal)?;
+    require_admin_full(&state, &principal)?;
 
     let usb_serial = req.usb_serial.trim().to_string();
     if usb_serial.is_empty() {

--- a/crates/susi_server/src/main.rs
+++ b/crates/susi_server/src/main.rs
@@ -439,6 +439,13 @@ struct ExportRequest {
     friendly_name: String,
 }
 
+#[derive(Deserialize)]
+struct ExportTokenRequest {
+    usb_serial: String,
+    #[serde(default)]
+    friendly_name: String,
+}
+
 #[derive(Serialize)]
 struct ErrorResponse {
     error: String,
@@ -2013,6 +2020,83 @@ async fn handle_export_license(
             ),
         ],
         json,
+    ))
+}
+
+async fn handle_export_token(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(key): Path<String>,
+    Json(req): Json<ExportTokenRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    let principal = validate_principal(&headers, &state)?;
+    require_password_changed(&state, &principal)?;
+    require_admin(&state, &principal)?;
+
+    let usb_serial = req.usb_serial.trim().to_string();
+    if usb_serial.is_empty() {
+        return Err(error_response(StatusCode::BAD_REQUEST, "USB serial is required"));
+    }
+
+    let db = state.db.lock().unwrap();
+    let license = db
+        .get_license_by_key(&key)
+        .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
+        .ok_or_else(|| error_response(StatusCode::NOT_FOUND, "License key not found"))?;
+
+    if license.revoked {
+        return Err(error_response(StatusCode::FORBIDDEN, "License has been revoked"));
+    }
+    if license.is_expired() {
+        return Err(error_response(StatusCode::FORBIDDEN, "License has expired"));
+    }
+
+    let activation_code = format!("usb:{}", usb_serial);
+
+    if !license.is_machine_activated(&activation_code) && !license.can_add_machine() {
+        return Err(error_response(
+            StatusCode::FORBIDDEN,
+            &format!("Machine limit reached (max {})", license.max_machines),
+        ));
+    }
+
+    let name = if req.friendly_name.is_empty() {
+        format!("USB Token: {}", usb_serial)
+    } else {
+        req.friendly_name.clone()
+    };
+
+    db.add_machine_activation(&license.id, &activation_code, &name, None)
+        .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
+
+    let payload = susi_core::LicensePayload {
+        id: license.id.clone(),
+        product: license.product.clone(),
+        customer: license.customer.clone(),
+        license_key: license.license_key.clone(),
+        created: license.created,
+        expires: license.expires,
+        features: license.features.clone(),
+        machine_codes: vec![activation_code],
+        lease_expires: None,
+    };
+
+    let signed = sign_license(&state.private_key, &payload)
+        .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
+
+    let blob = susi_core::encrypt_token(&signed, &usb_serial)
+        .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
+
+    Ok((
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "application/octet-stream"),
+            (
+                header::CONTENT_DISPOSITION,
+                "attachment; filename=\"license.bin\"",
+            ),
+        ],
+        blob,
     ))
 }
 
@@ -4332,6 +4416,7 @@ async fn main() -> Result<()> {
         .route("/api/v1/licenses/{key}", get(handle_get_license).put(handle_update_license).delete(handle_delete_license))
         .route("/api/v1/licenses/{key}/revoke", post(handle_revoke_license))
         .route("/api/v1/licenses/{key}/export", post(handle_export_license))
+        .route("/api/v1/licenses/{key}/export-token", post(handle_export_token))
         .route(
             "/api/v1/licenses/{key}/machines/{machine_code}",
             axum::routing::delete(handle_deactivate_machine),


### PR DESCRIPTION
This PR adds a possibility to export token files from the web interface. For that the serial number must be entered in the export dialog. It also adds a small command line tool (`susi_helper`) which can be used to get the fingerprint of the current machine and list the USB serial numbers of connected USB drivers.

Closes #20 and #21 