### PR TITLE
Use grace period of license instead of hardcoded values

### DIFF
--- a/cpp/include/susi.h
+++ b/cpp/include/susi.h
@@ -65,8 +65,6 @@ public:
 
     /// Returns true if the lease is expired past the grace period.
     bool isLeaseExpired() const;
-
-    void setGraceHours(int64_t hours) { m_graceHours = hours; }
 private:
     /// Verifies the signature of the signed license JSON string and returns the license status.
     /// If activation code is not provided, the local machine code is used.

--- a/cpp/src/susi.cpp
+++ b/cpp/src/susi.cpp
@@ -51,6 +51,8 @@ using json = nlohmann::json;
 #define SUSI_LOG(fmt, ...) fprintf(stderr, "[susi] " fmt "\n", ##__VA_ARGS__)
 #endif
 
+const int DEFAULT_LEASE_GRACE_HOURS = 24;
+
 // ---------------------------------------------------------------------------
 // Base64 decoding (OpenSSL)
 // ---------------------------------------------------------------------------
@@ -540,6 +542,12 @@ SusiClient::LicenseStatus SusiClient::verifySignedLicenseJson(const std::string&
     }
 
     // Check lease expiry
+    if (payload.contains("lease_grace_period") && payload.at("lease_grace_period").is_number_unsigned()) {
+        m_graceHours = payload.at("lease_grace_period").get<int64_t>();
+    } else {
+        m_graceHours = DEFAULT_LEASE_GRACE_HOURS;
+    }
+
     bool inGracePeriod = false;
     if (payload.contains("lease_expires") && !payload.at("lease_expires").is_null()) {
         std::string leaseStr = payload.at("lease_expires").get<std::string>();
@@ -605,6 +613,7 @@ SusiClient::LicenseStatus SusiClient::checkLicense(const std::filesystem::path& 
     m_product.clear();
     m_customer.clear();
     m_leaseExpiresEpoch = 0;
+    m_graceHours = DEFAULT_LEASE_GRACE_HOURS;
 
     std::ifstream licenseFile(licensePath);
     if (!licenseFile.is_open()) {
@@ -628,6 +637,7 @@ SusiClient::LicenseStatus SusiClient::checkLicenseAndRefresh(const std::filesyst
     m_product.clear();
     m_customer.clear();
     m_leaseExpiresEpoch = 0;
+    m_graceHours = DEFAULT_LEASE_GRACE_HOURS;
 
     if (!m_serverUrl.empty()) {
         std::string url = m_serverUrl;
@@ -1136,6 +1146,7 @@ SusiClient::LicenseStatus SusiClient::checkLicenseToken()
     m_product.clear();
     m_customer.clear();
     m_leaseExpiresEpoch = 0;
+    m_graceHours = DEFAULT_LEASE_GRACE_HOURS;
 
     auto devices = enumerateUsbDevices();
     if (devices.empty()) {

--- a/crates/susi_admin/src/main.rs
+++ b/crates/susi_admin/src/main.rs
@@ -536,6 +536,7 @@ fn cmd_export_token(
         features: license.features.clone(),
         machine_codes: vec![activation_code],
         lease_expires: None,
+        lease_grace_period: None,
     };
 
     let signed = sign_license(&private_key, &payload)?;

--- a/crates/susi_client/src/lib.rs
+++ b/crates/susi_client/src/lib.rs
@@ -112,8 +112,6 @@ impl LicenseStatus {
 pub struct LicenseClient {
     public_key: RsaPublicKey,
     server_url: Option<String>,
-    /// Grace period in hours after lease expiry. Default: 24.
-    grace_hours: i64,
     /// Optional on-disk cache for the machine fingerprint. When set, once the
     /// fingerprint has been computed successfully it is reused on subsequent
     /// runs even if the underlying hardware ID lookup later fails transiently.
@@ -127,7 +125,6 @@ impl LicenseClient {
         Ok(Self {
             public_key,
             server_url: None,
-            grace_hours: susi_core::DEFAULT_LEASE_GRACE_HOURS as i64,
             machine_code_cache: None,
         })
     }
@@ -137,11 +134,6 @@ impl LicenseClient {
         let mut client = Self::new(public_key_pem)?;
         client.server_url = Some(server_url);
         Ok(client)
-    }
-
-    /// Set the grace period (hours) for lease expiry.
-    pub fn set_grace_hours(&mut self, hours: i64) {
-        self.grace_hours = hours;
     }
 
     /// Set a path where the computed machine fingerprint is cached. See
@@ -222,9 +214,12 @@ impl LicenseClient {
             };
         }
 
-        // Check lease expiry
+        // Check lease expiry; prefer grace hours from the payload over the client default
         if payload.is_lease_expired() {
-            if payload.is_in_grace_period(self.grace_hours) {
+            let grace_hours = payload.lease_grace_period
+                .map(|h| h as i64)
+                .unwrap_or(susi_core::DEFAULT_LEASE_GRACE_HOURS as i64);
+            if payload.is_in_grace_period(grace_hours) {
                 return LicenseStatus::ValidGracePeriod {
                     lease_expired_at: payload.lease_expires.unwrap(),
                     payload,
@@ -518,6 +513,7 @@ mod tests {
             features: vec!["full_fusion".to_string(), "recorder".to_string()],
             machine_codes: machine_code.into_iter().collect(),
             lease_expires: None,
+            lease_grace_period: None,
         }
     }
 
@@ -582,6 +578,7 @@ mod tests {
             features: vec![],
             machine_codes: vec![],
             lease_expires: None,
+            lease_grace_period: None,
         };
         let signed = sign_license(&private, &payload).unwrap();
 
@@ -661,6 +658,7 @@ mod tests {
             features: vec!["full_fusion".to_string()],
             machine_codes: vec![],
             lease_expires: None,
+            lease_grace_period: None,
         };
         let signed = sign_license(&private, &payload).unwrap();
 
@@ -687,11 +685,11 @@ mod tests {
     #[test]
     fn test_verify_expired_lease_in_grace() {
         let (_, pub_pem, private) = make_keypair_pems();
-        let mut client = new_test_client(&pub_pem);
-        client.set_grace_hours(24);
+        let client = new_test_client(&pub_pem);
 
-        let mut payload = make_valid_payload(None);
+        let mut payload: LicensePayload = make_valid_payload(None);
         payload.lease_expires = Some(Utc::now() - Duration::hours(2)); // expired 2h ago
+        payload.lease_grace_period = Some(24);
         let signed = sign_license(&private, &payload).unwrap();
 
         let status = client.verify_signed(&signed);
@@ -703,11 +701,11 @@ mod tests {
     #[test]
     fn test_verify_expired_lease_past_grace() {
         let (_, pub_pem, private) = make_keypair_pems();
-        let mut client = new_test_client(&pub_pem);
-        client.set_grace_hours(24);
+        let client = new_test_client(&pub_pem);
 
         let mut payload = make_valid_payload(None);
         payload.lease_expires = Some(Utc::now() - Duration::hours(48)); // expired 48h ago
+        payload.lease_grace_period = Some(24);
         let signed = sign_license(&private, &payload).unwrap();
 
         let status = client.verify_signed(&signed);
@@ -914,6 +912,7 @@ mod tests {
             features: vec![],
             machine_codes: vec![],
             lease_expires: Some(Utc::now() + Duration::hours(168)),
+            lease_grace_period: None,
         };
         let signed = sign_license(&private, &payload).unwrap();
         let body = serde_json::to_string(&signed).unwrap();

--- a/crates/susi_core/src/crypto.rs
+++ b/crates/susi_core/src/crypto.rs
@@ -93,6 +93,7 @@ mod tests {
             features: vec!["full_fusion".to_string(), "recorder".to_string()],
             machine_codes: vec!["abc123def456".to_string()],
             lease_expires: None,
+            lease_grace_period: None,
         }
     }
 

--- a/crates/susi_core/src/license.rs
+++ b/crates/susi_core/src/license.rs
@@ -51,6 +51,9 @@ pub struct LicensePayload {
     /// time or the license stops being valid.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lease_expires: Option<DateTime<Utc>>,
+    /// Grace period in hours after lease expiry. `None` means use client default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lease_grace_period: Option<u32>,
 }
 
 /// A signed license file that can be written to disk and verified offline.
@@ -99,6 +102,8 @@ impl License {
                 .and_then(|m| m.lease_expires_at)
         });
 
+        let lease_grace_period = lease_expires.map(|_| self.lease_grace_hours);
+
         LicensePayload {
             id: self.id.clone(),
             product: self.product.clone(),
@@ -109,6 +114,7 @@ impl License {
             features: self.features.clone(),
             machine_codes: self.active_machine_codes(),
             lease_expires,
+            lease_grace_period,
         }
     }
 
@@ -201,9 +207,13 @@ impl LicensePayload {
     }
 
     /// Check if the lease is expired but still within the grace period.
-    pub fn is_in_grace_period(&self, grace_hours: i64) -> bool {
+    /// Uses `self.lease_grace_hours` when present, otherwise falls back to `default_grace_hours`.
+    pub fn is_in_grace_period(&self, default_grace_hours: i64) -> bool {
         match self.lease_expires {
             Some(dt) => {
+                let grace_hours = self.lease_grace_period
+                    .map(|h| h as i64)
+                    .unwrap_or(default_grace_hours);
                 let now = Utc::now();
                 let grace_end = dt + chrono::Duration::hours(grace_hours);
                 now > dt && now <= grace_end
@@ -405,6 +415,7 @@ mod tests {
             features: vec![],
             machine_codes: vec![],
             lease_expires: Some(future),
+            lease_grace_period: None,
         };
         assert!(!payload.is_lease_expired());
 
@@ -429,6 +440,7 @@ mod tests {
             features: vec!["full_fusion".to_string(), "recorder".to_string()],
             machine_codes: vec!["machine1".to_string()],
             lease_expires: None,
+            lease_grace_period: None,
         };
 
         assert!(payload.has_feature("full_fusion"));
@@ -450,6 +462,7 @@ mod tests {
             features: vec![],
             machine_codes: vec![],
             lease_expires: None,
+            lease_grace_period: None,
         };
 
         assert!(payload.is_machine_authorized("any_machine"));

--- a/crates/susi_server/src/main.rs
+++ b/crates/susi_server/src/main.rs
@@ -2078,6 +2078,7 @@ async fn handle_export_token(
         features: license.features.clone(),
         machine_codes: vec![activation_code],
         lease_expires: None,
+        lease_grace_period: None,
     };
 
     let signed = sign_license(&state.private_key, &payload)


### PR DESCRIPTION
- Put the grace period which is already stored in the license into the license json
- Read this value in the clients and use it
- Only fallback to default value if no value is present (backwards compatibility)
- Remove grace hours attribute from clients

Closes #23 