### PR TITLE
Refresh selected license correctly.

### DIFF
--- a/crates/susi_server/src/dashboard.html
+++ b/crates/susi_server/src/dashboard.html
@@ -2150,6 +2150,7 @@ async function loadLicenses() {
         status.textContent = 'Connected';
         status.className = 'status ok';
         renderTable();
+        if (selectedKey) selectLicense(selectedKey);
     } catch (e) {
         status.textContent = 'Disconnected';
         status.className = 'status err';


### PR DESCRIPTION
There was a bug, where the currently selected license (detail windows) was not refreshed, when "Refresh" was pressed. This PR fixes that.

Closes #16 