### PR TITLE
Simplify workspace permissions and admin access

### DIFF
--- a/crates/susi_admin/src/main.rs
+++ b/crates/susi_admin/src/main.rs
@@ -262,7 +262,7 @@ fn cmd_seed_e2e_workspace(
             username,
         )?;
     } else {
-        db.add_workspace_member(workspace_id, username, "owner")?;
+        db.add_workspace_member(workspace_id, username)?;
     }
 
     println!(

--- a/crates/susi_client/src/workspace.rs
+++ b/crates/susi_client/src/workspace.rs
@@ -19,14 +19,11 @@ pub struct WorkspaceInfo {
     pub created_at: String,
     #[serde(default)]
     pub updated_at: String,
-    #[serde(default)]
-    pub role: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct WorkspaceMember {
     pub username: String,
-    pub role: String,
     #[serde(default)]
     pub added_at: String,
 }
@@ -256,20 +253,18 @@ impl WorkspaceClient {
         &self,
         workspace_id: &str,
         username: &str,
-        role: &str,
     ) -> Result<(), WorkspaceError> {
-        blocking_run(self.add_member_async(workspace_id, username, role))
+        blocking_run(self.add_member_async(workspace_id, username))
     }
 
     pub async fn add_member_async(
         &self,
         workspace_id: &str,
         username: &str,
-        role: &str,
     ) -> Result<(), WorkspaceError> {
         self.post_void(
             &format!("/api/v1/workspaces/{}/members", workspace_id),
-            &serde_json::json!({ "username": username, "role": role }),
+            &serde_json::json!({ "username": username }),
         )
         .await
     }

--- a/crates/susi_core/src/db.rs
+++ b/crates/susi_core/src/db.rs
@@ -207,7 +207,6 @@ impl LicenseDb {
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 workspace_id TEXT NOT NULL,
                 username TEXT NOT NULL,
-                role TEXT NOT NULL DEFAULT 'viewer',
                 added_at TEXT NOT NULL,
                 FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
                 UNIQUE(workspace_id, username)
@@ -528,6 +527,14 @@ impl LicenseDb {
         let _ = self.conn.execute_batch(
             "ALTER TABLE workspace_peers ADD COLUMN network_id TEXT NOT NULL DEFAULT '';",
         );
+
+        // Workspace member roles (viewer/editor/owner) were retired: membership
+        // alone grants full read+write, management stays site-admin-only. Drop
+        // the now-unused column. The error on a fresh DB (no such column) is
+        // ignored.
+        let _ = self
+            .conn
+            .execute_batch("ALTER TABLE workspace_members DROP COLUMN role;");
 
         // Migrate single-admin table to multi-user table
         let has_admin_user: bool = self
@@ -1954,6 +1961,21 @@ impl LicenseDb {
             .map_err(|e| LicenseError::Other(format!("DB query: {}", e)))
     }
 
+    pub fn set_user_role(&self, username: &str, role: &str) -> Result<(), LicenseError> {
+        let now = Utc::now().to_rfc3339();
+        let n = self
+            .conn
+            .execute(
+                "UPDATE users SET role = ?2, updated_at = ?3 WHERE username = ?1",
+                params![username, role, now],
+            )
+            .map_err(|e| LicenseError::Other(format!("DB update: {}", e)))?;
+        if n == 0 {
+            return Err(LicenseError::Other("User not found".into()));
+        }
+        Ok(())
+    }
+
     /// Single-row fetch of every user attribute the admin gate needs:
     /// (role, must_change_password, totp_enabled). Replaces the three
     /// separate `get_user_role` / `user_must_change_password` /
@@ -1996,9 +2018,8 @@ impl LicenseDb {
     /// Rename a user across every username-keyed table, atomically. Tables
     /// with a uniqueness constraint on (x, username) can already hold rows
     /// under the new name (e.g. left over from an earlier partial rename, or
-    /// memberships added by hand) - those are merged instead of renamed: the
-    /// surviving membership keeps the more privileged role, duplicate rows
-    /// are dropped. Without the merge a plain UPDATE aborts on the unique
+    /// memberships added by hand) - those are merged instead of renamed:
+    /// duplicate membership rows are dropped. Without the merge a plain UPDATE aborts on the unique
     /// constraint and a non-transactional rename leaves half the tables on
     /// the old name.
     pub fn rename_user(&self, old_username: &str, new_username: &str) -> Result<(), LicenseError> {
@@ -2030,13 +2051,8 @@ impl LicenseDb {
                 params![new_username, now, old_username],
             )
             .map_err(|e| LicenseError::Other(format!("DB update: {}", e)))?;
-        // Workspace memberships: upgrade the surviving row where the old
-        // account outranks it (owner > editor > viewer), drop the now
-        // duplicate rows, rename the rest.
-        run("UPDATE workspace_members SET role = 'owner' WHERE username = ?1 AND role != 'owner'
-             AND workspace_id IN (SELECT workspace_id FROM workspace_members WHERE username = ?2 AND role = 'owner')")?;
-        run("UPDATE workspace_members SET role = 'editor' WHERE username = ?1 AND role = 'viewer'
-             AND workspace_id IN (SELECT workspace_id FROM workspace_members WHERE username = ?2 AND role = 'editor')")?;
+        // Workspace memberships: drop the now-duplicate row where the new name
+        // is already a member, then rename the rest.
         run("DELETE FROM workspace_members WHERE username = ?2
              AND workspace_id IN (SELECT workspace_id FROM workspace_members WHERE username = ?1)")?;
         run("UPDATE workspace_members SET username = ?1 WHERE username = ?2")?;
@@ -2091,11 +2107,11 @@ impl LicenseDb {
                 params![id, name, product, description, created_by, now],
             )
             .map_err(|e| LicenseError::Other(format!("DB insert workspace: {}", e)))?;
-        // Add creator as owner
+        // Add creator as a member
         self.conn
             .execute(
-                "INSERT INTO workspace_members (workspace_id, username, role, added_at)
-                 VALUES (?1, ?2, 'owner', ?3)",
+                "INSERT INTO workspace_members (workspace_id, username, added_at)
+                 VALUES (?1, ?2, ?3)",
                 params![id, created_by, now],
             )
             .map_err(|e| LicenseError::Other(format!("DB insert workspace member: {}", e)))?;
@@ -2141,13 +2157,12 @@ impl LicenseDb {
             String,
             String,
             String,
-            String,
         )>,
         LicenseError,
     > {
         let mut stmt = self.conn
             .prepare(
-                "SELECT w.id, w.name, w.product, w.description, w.created_by, w.created_at, w.updated_at, wm.role
+                "SELECT w.id, w.name, w.product, w.description, w.created_by, w.created_at, w.updated_at
                  FROM workspaces w
                  JOIN workspace_members wm ON w.id = wm.workspace_id
                  WHERE wm.username = ?1
@@ -2164,7 +2179,6 @@ impl LicenseDb {
                     r.get::<_, String>(4)?,
                     r.get::<_, String>(5)?,
                     r.get::<_, String>(6)?,
-                    r.get::<_, String>(7)?,
                 ))
             })
             .map_err(|e| LicenseError::Other(format!("DB query: {}", e)))?
@@ -2173,14 +2187,11 @@ impl LicenseDb {
         Ok(rows)
     }
 
-    /// List every workspace (admin view). `username` is used only to fill in
-    /// the caller's per-workspace role; it is empty where they are not a member.
+    /// List every workspace (admin view).
     pub fn list_all_workspaces(
         &self,
-        username: &str,
     ) -> Result<
         Vec<(
-            String,
             String,
             String,
             String,
@@ -2193,14 +2204,13 @@ impl LicenseDb {
     > {
         let mut stmt = self.conn
             .prepare(
-                "SELECT w.id, w.name, w.product, w.description, w.created_by, w.created_at, w.updated_at, COALESCE(wm.role, '')
-                 FROM workspaces w
-                 LEFT JOIN workspace_members wm ON w.id = wm.workspace_id AND wm.username = ?1
-                 ORDER BY w.name"
+                "SELECT id, name, product, description, created_by, created_at, updated_at
+                 FROM workspaces
+                 ORDER BY name"
             )
             .map_err(|e| LicenseError::Other(format!("DB prepare: {}", e)))?;
         let rows = stmt
-            .query_map(params![username], |r| {
+            .query_map([], |r| {
                 Ok((
                     r.get::<_, String>(0)?,
                     r.get::<_, String>(1)?,
@@ -2209,7 +2219,6 @@ impl LicenseDb {
                     r.get::<_, String>(4)?,
                     r.get::<_, String>(5)?,
                     r.get::<_, String>(6)?,
-                    r.get::<_, String>(7)?,
                 ))
             })
             .map_err(|e| LicenseError::Other(format!("DB query: {}", e)))?
@@ -2260,15 +2269,14 @@ impl LicenseDb {
         &self,
         workspace_id: &str,
         username: &str,
-        role: &str,
     ) -> Result<(), LicenseError> {
         let now = Utc::now().to_rfc3339();
         self.conn
             .execute(
-                "INSERT INTO workspace_members (workspace_id, username, role, added_at)
-                 VALUES (?1, ?2, ?3, ?4)
-                 ON CONFLICT(workspace_id, username) DO UPDATE SET role = excluded.role",
-                params![workspace_id, username, role, now],
+                "INSERT INTO workspace_members (workspace_id, username, added_at)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT(workspace_id, username) DO NOTHING",
+                params![workspace_id, username, now],
             )
             .map_err(|e| LicenseError::Other(format!("DB insert member: {}", e)))?;
         Ok(())
@@ -2292,10 +2300,10 @@ impl LicenseDb {
     pub fn list_workspace_members(
         &self,
         workspace_id: &str,
-    ) -> Result<Vec<(String, String, String)>, LicenseError> {
+    ) -> Result<Vec<(String, String)>, LicenseError> {
         let mut stmt = self.conn
             .prepare(
-                "SELECT username, role, added_at FROM workspace_members WHERE workspace_id = ?1 ORDER BY added_at"
+                "SELECT username, added_at FROM workspace_members WHERE workspace_id = ?1 ORDER BY added_at"
             )
             .map_err(|e| LicenseError::Other(format!("DB prepare: {}", e)))?;
         let rows = stmt
@@ -2303,7 +2311,6 @@ impl LicenseDb {
                 Ok((
                     r.get::<_, String>(0)?,
                     r.get::<_, String>(1)?,
-                    r.get::<_, String>(2)?,
                 ))
             })
             .map_err(|e| LicenseError::Other(format!("DB query: {}", e)))?
@@ -2312,17 +2319,24 @@ impl LicenseDb {
         Ok(rows)
     }
 
-    pub fn get_workspace_member_role(
+    /// `Some(())` if the user may access this workspace: a site admin (admins
+    /// can administer any workspace) or a member. `None` otherwise. Membership
+    /// grants full read+write; management (add/remove members, delete) stays
+    /// gated on site-admin in the handler layer.
+    pub fn workspace_access(
         &self,
         workspace_id: &str,
         username: &str,
-    ) -> Result<Option<String>, LicenseError> {
+    ) -> Result<Option<()>, LicenseError> {
+        if self.get_user_role(username).map(|r| r == "admin").unwrap_or(false) {
+            return Ok(Some(()));
+        }
         match self.conn.query_row(
-            "SELECT role FROM workspace_members WHERE workspace_id = ?1 AND username = ?2",
+            "SELECT 1 FROM workspace_members WHERE workspace_id = ?1 AND username = ?2",
             params![workspace_id, username],
-            |r| r.get(0),
+            |_| Ok(()),
         ) {
-            Ok(role) => Ok(Some(role)),
+            Ok(()) => Ok(Some(())),
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
             Err(e) => Err(LicenseError::Other(format!("DB query: {}", e))),
         }
@@ -5592,12 +5606,11 @@ mod tests {
     }
 
     #[test]
-    fn test_workspace_creator_is_owner() {
+    fn test_workspace_creator_is_member() {
         let db = test_db();
         db.create_workspace("ws-1", "WS", "", "", "admin").unwrap();
 
-        let role = db.get_workspace_member_role("ws-1", "admin").unwrap();
-        assert_eq!(role, Some("owner".to_string()));
+        assert!(db.workspace_access("ws-1", "admin").unwrap().is_some());
     }
 
     #[test]
@@ -5620,36 +5633,25 @@ mod tests {
         let db = test_db();
         db.create_workspace("ws-1", "WS", "", "", "admin").unwrap();
 
-        db.add_workspace_member("ws-1", "user1", "editor").unwrap();
-        db.add_workspace_member("ws-1", "user2", "viewer").unwrap();
+        db.add_workspace_member("ws-1", "user1").unwrap();
+        db.add_workspace_member("ws-1", "user2").unwrap();
 
         let members = db.list_workspace_members("ws-1").unwrap();
         assert_eq!(members.len(), 3); // admin + user1 + user2
 
-        assert_eq!(
-            db.get_workspace_member_role("ws-1", "user1").unwrap(),
-            Some("editor".to_string())
-        );
-        assert_eq!(
-            db.get_workspace_member_role("ws-1", "user2").unwrap(),
-            Some("viewer".to_string())
-        );
-        assert_eq!(
-            db.get_workspace_member_role("ws-1", "nobody").unwrap(),
-            None
-        );
+        assert!(db.workspace_access("ws-1", "user1").unwrap().is_some());
+        assert!(db.workspace_access("ws-1", "user2").unwrap().is_some());
+        assert!(db.workspace_access("ws-1", "nobody").unwrap().is_none());
 
-        // Update role via upsert
-        db.add_workspace_member("ws-1", "user2", "editor").unwrap();
-        assert_eq!(
-            db.get_workspace_member_role("ws-1", "user2").unwrap(),
-            Some("editor".to_string())
-        );
+        // Adding an existing member is idempotent.
+        db.add_workspace_member("ws-1", "user2").unwrap();
+        assert_eq!(db.list_workspace_members("ws-1").unwrap().len(), 3);
 
         // Remove member
         db.remove_workspace_member("ws-1", "user1").unwrap();
         let members = db.list_workspace_members("ws-1").unwrap();
         assert_eq!(members.len(), 2);
+        assert!(db.workspace_access("ws-1", "user1").unwrap().is_none());
     }
 
     #[test]
@@ -5672,7 +5674,7 @@ mod tests {
     fn test_delete_workspace_cascades() {
         let db = test_db();
         db.create_workspace("ws-1", "WS", "", "", "admin").unwrap();
-        db.add_workspace_member("ws-1", "user1", "viewer").unwrap();
+        db.add_workspace_member("ws-1", "user1").unwrap();
         db.push_config_revision("ws-1", "{}", "init", "", "admin")
             .unwrap();
 

--- a/crates/susi_server/src/dashboard.html
+++ b/crates/susi_server/src/dashboard.html
@@ -721,17 +721,12 @@ body:has(.modal-overlay.visible) { overflow: hidden; }
                     <div class="field-label">Created By</div>
                     <div class="field-value" id="wsDetailCreatedBy"></div>
                 </div>
-                <div class="detail-field">
-                    <div class="field-label">Your Role</div>
-                    <div class="field-value" id="wsDetailRole"></div>
-                </div>
             </div>
 
             <div class="ws-tabs" role="tablist">
                 <button class="ws-tab active" data-ws-tab="releases" onclick="setWsTab('releases')">Releases</button>
                 <button class="ws-tab" data-ws-tab="configs" onclick="setWsTab('configs')">Configs</button>
                 <button class="ws-tab" data-ws-tab="recordings" onclick="setWsTab('recordings')">Recordings</button>
-                <button class="ws-tab" data-ws-tab="instances" onclick="setWsTab('instances')">Instances</button>
                 <button class="ws-tab" data-ws-tab="members" onclick="setWsTab('members')">Members</button>
                 <button class="ws-tab" data-ws-tab="settings" data-ws-admin-only onclick="setWsTab('settings')">Settings</button>
             </div>
@@ -759,24 +754,11 @@ body:has(.modal-overlay.visible) { overflow: hidden; }
                 <div id="wsDetailRecordings" class="machines-list"></div>
             </div>
 
-            <div class="ws-tab-panel" data-ws-panel="instances">
-                <div class="detail-section-title" style="display:flex;align-items:center;justify-content:space-between;">
-                    <span>Connected Instances</span>
-                    <button class="small" onclick="loadWsInstances(selectedWsId)">Refresh</button>
-                </div>
-                <div id="wsDetailInstances" class="machines-list"></div>
-            </div>
-
             <div class="ws-tab-panel" data-ws-panel="members">
                 <div class="detail-section-title">Members</div>
                 <div id="wsDetailMembers" class="machines-list"></div>
                 <div id="wsAddMemberRow" style="display:flex;gap:8px;margin-top:8px;">
                     <select id="wsNewMember" style="flex:1;"><option value="">Select user...</option></select>
-                    <select id="wsNewMemberRole" style="width:100px;">
-                        <option value="viewer">Viewer</option>
-                        <option value="editor">Editor</option>
-                        <option value="owner">Owner</option>
-                    </select>
                     <button class="small" onclick="addWsMember()">Add</button>
                 </div>
             </div>
@@ -3375,6 +3357,9 @@ async function loadUsers() {
                 ? '<button onclick="resendInvitation(\'' + uname + '\')">' +
                   (u.pending_invitation ? 'Resend invite' : 'Send invite') + '</button>'
                 : '';
+            const roleItem = u.role === 'admin'
+                ? '<button onclick="setUserRole(\'' + uname + '\',\'user\')">Revoke admin</button>'
+                : '<button onclick="setUserRole(\'' + uname + '\',\'admin\')">Make admin</button>';
             const emailItem = '<button onclick="setUserEmail(\'' + uname + '\',' + emailArg + ')">' +
                               (u.email ? 'Edit email' : 'Set email') + '</button>';
             // Self row keeps a reduced Actions menu (rename + email) so admins
@@ -3396,6 +3381,7 @@ async function loadUsers() {
                       emailItem +
                       resendItem +
                       '<button onclick="resetUserPassword(\'' + uname + '\')">Reset password</button>' +
+                      roleItem +
                       '<div class="divider"></div>' +
                       '<button class="danger" onclick="deleteUser(\'' + uname + '\')">Delete</button>' +
                     '</div>' +
@@ -3534,6 +3520,27 @@ async function resetUserPassword(username) {
             return;
         }
         toast('Password reset for "' + username + '"', 'success');
+        await loadUsers();
+    } catch (e) {
+        toast('Failed: ' + e.message, 'error');
+    }
+}
+
+async function setUserRole(username, role) {
+    const verb = role === 'admin' ? 'Grant admin rights to' : 'Revoke admin rights from';
+    if (!confirm(verb + ' ' + username + '?')) return;
+    try {
+        const resp = await fetch(API + '/auth/users/' + encodeURIComponent(username) + '/role', {
+            method: 'PUT',
+            headers: authHeaders(),
+            body: JSON.stringify({ role }),
+        });
+        if (!resp.ok) {
+            const data = await resp.json();
+            toast('Error: ' + data.error, 'error');
+            return;
+        }
+        toast(role === 'admin' ? username + ' is now an admin' : username + ' is now a user', 'success');
         await loadUsers();
     } catch (e) {
         toast('Failed: ' + e.message, 'error');
@@ -4169,7 +4176,6 @@ function renderWorkspaces() {
                         <th>Name</th>
                         <th>Product</th>
                         <th>Description</th>
-                        <th>Role</th>
                         <th>Created by</th>
                     </tr>
                 </thead>
@@ -4179,7 +4185,6 @@ function renderWorkspaces() {
                             <td style="font-weight:600;">${esc(ws.name)}</td>
                             <td>${ws.product ? `<span class="badge active">${esc(ws.product)}</span>` : ''}</td>
                             <td style="color:var(--text2);">${ws.description ? esc(ws.description) : ''}</td>
-                            <td style="color:var(--text2);">${esc(ws.role ? ws.role.charAt(0).toUpperCase() + ws.role.slice(1) : 'Not a member')}</td>
                             <td style="color:var(--text2);">${esc(ws.created_by)}</td>
                         </tr>
                     `).join('')}
@@ -4206,7 +4211,6 @@ async function showWsDetail(id) {
         document.getElementById('wsDetailProduct').textContent = ws.product || '-';
         document.getElementById('wsDetailDesc').textContent = ws.description || '-';
         document.getElementById('wsDetailCreatedBy').textContent = ws.created_by;
-        document.getElementById('wsDetailRole').textContent = ws.role ? ws.role.charAt(0).toUpperCase() + ws.role.slice(1) : '';
 
         // Members
         const members = ws.members || [];
@@ -4214,7 +4218,7 @@ async function showWsDetail(id) {
             ? '<div style="color:var(--text2);font-size:13px;">No members</div>'
             : members.map(m => `
                 <div class="machine-item">
-                    <span style="display:flex;align-items:center;gap:8px;"><strong style="min-width:200px;">${esc(m.username)}</strong> <span class="badge active" style="font-size:10px;">${esc(m.role.toUpperCase())}</span></span>
+                    <span style="display:flex;align-items:center;gap:8px;"><strong style="min-width:200px;">${esc(m.username)}</strong></span>
                     ${userRole === 'admin' ? `<button class="small danger" onclick="removeWsMember('${id}','${esc(m.username)}')">Remove</button>` : ''}
                 </div>
             `).join('');
@@ -4275,7 +4279,6 @@ async function showWsDetail(id) {
         // Load configs and the unified releases list.
         loadWsConfigs(id);
         loadWsReleases(id);
-        loadWsInstances(id);
         loadWsRecordings(id);
     } catch (e) {
         toast('Error: ' + e.message, 'error');
@@ -4883,58 +4886,16 @@ async function deleteWsRecording(id) {
     }
 }
 
-// Render registered FusionHub peers for the workspace. Peers re-register every
-// 30s, so anything seen within 90s (3 ticks) is treated as currently online.
-async function loadWsInstances(wsId) {
-    if (!wsId) return;
-    const container = document.getElementById('wsDetailInstances');
-    try {
-        const resp = await fetch(API + '/workspaces/' + wsId + '/federation', { headers: authHeaders() });
-        if (!resp.ok) { container.innerHTML = '<div style="color:var(--text2);font-size:13px;">Failed to load</div>'; return; }
-        const data = await resp.json();
-        const peers = data.peers || [];
-        if (peers.length === 0) {
-            container.innerHTML = '<div style="color:var(--text2);font-size:13px;">No FusionHub instances have registered with this workspace.</div>';
-            return;
-        }
-        const now = Date.now();
-        container.innerHTML = peers.map(p => {
-            const seenMs = p.last_seen ? new Date(p.last_seen).getTime() : 0;
-            const ageS = seenMs ? Math.max(0, Math.floor((now - seenMs) / 1000)) : null;
-            const online = ageS !== null && ageS <= 90;
-            const dotColor = online ? '#3fb950' : 'var(--text2)';
-            const ageLabel = ageS === null ? 'never'
-                : ageS < 60 ? ageS + 's ago'
-                : ageS < 3600 ? Math.floor(ageS / 60) + 'm ago'
-                : ageS < 86400 ? Math.floor(ageS / 3600) + 'h ago'
-                : Math.floor(ageS / 86400) + 'd ago';
-            const label = p.label && p.label.trim() ? p.label : '(unnamed)';
-            const hostShort = (p.host_id || '').slice(0, 12);
-            return '<div class="machine-item">' +
-                '<span style="display:flex;align-items:center;gap:10px;min-width:0;">' +
-                    '<span title="' + (online ? 'Online' : 'Last seen ' + ageLabel) + '" style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + dotColor + ';flex-shrink:0;"></span>' +
-                    '<strong style="min-width:160px;">' + esc(label) + '</strong>' +
-                    '<span class="machine-code" title="' + esc(p.host_id) + '">' + esc(hostShort) + '</span>' +
-                    '<span class="machine-code" style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + esc(p.url) + '</span>' +
-                '</span>' +
-                '<span class="machine-code">' + esc(p.registered_by) + ' &middot; ' + ageLabel + '</span>' +
-            '</div>';
-        }).join('');
-    } catch (e) {
-        container.innerHTML = '<div style="color:var(--text2);font-size:13px;">Failed to load instances</div>';
-    }
-}
 
 async function addWsMember() {
     const username = document.getElementById('wsNewMember').value;
-    const role = document.getElementById('wsNewMemberRole').value;
     if (!username) { toast('Select a user first', 'error'); return; }
     if (!selectedWsId) return;
     try {
         const resp = await fetch(API + '/workspaces/' + selectedWsId + '/members', {
             method: 'POST',
             headers: authHeaders(),
-            body: JSON.stringify({ username, role }),
+            body: JSON.stringify({ username }),
         });
         if (!resp.ok) {
             const data = await resp.json();

--- a/crates/susi_server/src/main.rs
+++ b/crates/susi_server/src/main.rs
@@ -847,7 +847,7 @@ pub(crate) fn release_writer_check(
 }
 
 /// Permission gate for reading a doc release. Workspace releases require
-/// admin or any-role membership; global releases are public.
+/// admin or workspace membership; global releases are public.
 pub(crate) fn release_reader_check(
     state: &AppState,
     principal_opt: Option<&Principal>,
@@ -869,7 +869,7 @@ pub(crate) fn release_reader_check(
     }
     let role = {
         let db = state.db.lock().unwrap();
-        db.get_workspace_member_role(&ws_id, &principal.username)
+        db.workspace_access(&ws_id, &principal.username)
             .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
     };
     if role.is_none() {
@@ -3057,6 +3057,38 @@ async fn handle_rename_user(
 }
 
 #[derive(Deserialize)]
+struct SetUserRoleRequest {
+    role: String,
+}
+
+async fn handle_set_user_role(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(username): Path<String>,
+    Json(req): Json<SetUserRoleRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = validate_principal(&headers, &state)?;
+    require_admin_full(&state, &principal)?;
+
+    if !matches!(req.role.as_str(), "admin" | "user") {
+        return Err(error_response(StatusCode::BAD_REQUEST, "Role must be admin or user"));
+    }
+    // Block self-demotion so an admin can't lock the org out of admin access.
+    if principal.username == username {
+        return Err(error_response(StatusCode::BAD_REQUEST, "Cannot change your own role"));
+    }
+
+    let db = state.db.lock().unwrap();
+    if !db.user_exists(&username).unwrap_or(false) {
+        return Err(error_response(StatusCode::NOT_FOUND, "User does not exist"));
+    }
+    db.set_user_role(&username, &req.role)
+        .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
+
+    Ok(Json(serde_json::json!({ "status": "OK" })))
+}
+
+#[derive(Deserialize)]
 struct ResetPasswordRequest {
     new_password: String,
 }
@@ -3543,7 +3575,7 @@ fn authorize_release_download(
             .map(|r| r == "admin")
             .unwrap_or(false);
         if !is_admin {
-            let role = db.get_workspace_member_role(&ws_id, &principal.username)
+            let role = db.workspace_access(&ws_id, &principal.username)
                 .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
             if role.is_none() {
                 return Err(error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"));
@@ -4081,12 +4113,6 @@ struct UpdateWorkspaceRequest {
 #[derive(Deserialize)]
 struct AddMemberRequest {
     username: String,
-    #[serde(default = "default_member_role")]
-    role: String,
-}
-
-fn default_member_role() -> String {
-    "viewer".to_string()
 }
 
 #[derive(Deserialize)]
@@ -4147,13 +4173,13 @@ async fn handle_list_workspaces(
         .map(|r| r == "admin")
         .unwrap_or(false);
     let rows = if is_admin {
-        db.list_all_workspaces(&principal.username)
+        db.list_all_workspaces()
     } else {
         db.list_workspaces_for_user(&principal.username)
     }
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
 
-    let workspaces: Vec<_> = rows.iter().map(|(id, name, product, desc, created_by, created_at, updated_at, role)| {
+    let workspaces: Vec<_> = rows.iter().map(|(id, name, product, desc, created_by, created_at, updated_at)| {
         serde_json::json!({
             "id": id,
             "name": name,
@@ -4162,7 +4188,6 @@ async fn handle_list_workspaces(
             "created_by": created_by,
             "created_at": created_at,
             "updated_at": updated_at,
-            "role": role,
         })
     }).collect();
 
@@ -4178,7 +4203,7 @@ async fn handle_get_workspace(
     require_password_changed(&state, &principal)?;
 
     let db = state.db.lock().unwrap();
-    let role = db.get_workspace_member_role(&id, &principal.username)
+    db.workspace_access(&id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
         .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
 
@@ -4197,9 +4222,8 @@ async fn handle_get_workspace(
         "created_by": ws.4,
         "created_at": ws.5,
         "updated_at": ws.6,
-        "role": role,
-        "members": members.iter().map(|(u, r, a)| serde_json::json!({
-            "username": u, "role": r, "added_at": a,
+        "members": members.iter().map(|(u, a)| serde_json::json!({
+            "username": u, "added_at": a,
         })).collect::<Vec<_>>(),
     })))
 }
@@ -4214,12 +4238,9 @@ async fn handle_update_workspace(
     require_password_changed(&state, &principal)?;
 
     let db = state.db.lock().unwrap();
-    let role = db.get_workspace_member_role(&id, &principal.username)
+    db.workspace_access(&id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
         .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
-    if role != "owner" && role != "editor" {
-        return Err(error_response(StatusCode::FORBIDDEN, "Insufficient permissions"));
-    }
 
     // Re-assigning the "created by" attribution is admin-only (the field is
     // mostly cosmetic but we want admins to be the gate). Validate the target
@@ -4275,15 +4296,11 @@ async fn handle_add_workspace_member(
 
     let db = state.db.lock().unwrap();
 
-    if !matches!(req.role.as_str(), "owner" | "editor" | "viewer") {
-        return Err(error_response(StatusCode::BAD_REQUEST, "Role must be owner, editor, or viewer"));
-    }
-
     if !db.user_exists(&req.username).unwrap_or(false) {
         return Err(error_response(StatusCode::NOT_FOUND, "User does not exist"));
     }
 
-    db.add_workspace_member(&workspace_id, &req.username, &req.role)
+    db.add_workspace_member(&workspace_id, &req.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
 
     Ok(Json(serde_json::json!({ "status": "OK" })))
@@ -4318,12 +4335,9 @@ async fn handle_push_config(
     require_password_changed(&state, &principal)?;
 
     let db = state.db.lock().unwrap();
-    let role = db.get_workspace_member_role(&workspace_id, &principal.username)
+    db.workspace_access(&workspace_id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
         .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
-    if role == "viewer" {
-        return Err(error_response(StatusCode::FORBIDDEN, "Viewers cannot push configs"));
-    }
 
     // Validate JSON
     serde_json::from_str::<serde_json::Value>(&req.config_json)
@@ -4347,7 +4361,7 @@ async fn handle_list_configs(
     require_password_changed(&state, &principal)?;
 
     let db = state.db.lock().unwrap();
-    db.get_workspace_member_role(&workspace_id, &principal.username)
+    db.workspace_access(&workspace_id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
         .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
 
@@ -4376,7 +4390,7 @@ async fn handle_get_config(
     require_password_changed(&state, &principal)?;
 
     let db = state.db.lock().unwrap();
-    db.get_workspace_member_role(&workspace_id, &principal.username)
+    db.workspace_access(&workspace_id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
         .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
 
@@ -4403,7 +4417,7 @@ async fn handle_get_latest_config(
     require_password_changed(&state, &principal)?;
 
     let db = state.db.lock().unwrap();
-    db.get_workspace_member_role(&workspace_id, &principal.username)
+    db.workspace_access(&workspace_id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
         .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
 
@@ -4431,12 +4445,9 @@ async fn handle_update_config(
     require_password_changed(&state, &principal)?;
 
     let db = state.db.lock().unwrap();
-    let role = db.get_workspace_member_role(&workspace_id, &principal.username)
+    db.workspace_access(&workspace_id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
         .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
-    if role == "viewer" {
-        return Err(error_response(StatusCode::FORBIDDEN, "Viewers cannot edit configs"));
-    }
 
     let updated = db.update_config_revision(&workspace_id, config_id, &req.name, &req.description, req.config_json.as_deref())
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
@@ -4456,12 +4467,9 @@ async fn handle_delete_config(
     require_password_changed(&state, &principal)?;
 
     let db = state.db.lock().unwrap();
-    let role = db.get_workspace_member_role(&workspace_id, &principal.username)
+    db.workspace_access(&workspace_id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
         .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
-    if role == "viewer" {
-        return Err(error_response(StatusCode::FORBIDDEN, "Viewers cannot delete configs"));
-    }
 
     let deleted = db.delete_config_revision(&workspace_id, config_id)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
@@ -4513,29 +4521,13 @@ fn s3_unavailable() -> (StatusCode, Json<ErrorResponse>) {
     )
 }
 
-fn assert_workspace_writer(
-    state: &AppState,
-    workspace_id: &str,
-    principal: &Principal,
-) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
-    let db = state.db.lock().unwrap();
-    let role = db
-        .get_workspace_member_role(workspace_id, &principal.username)
-        .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
-        .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
-    if role == "viewer" {
-        return Err(error_response(StatusCode::FORBIDDEN, "Viewers cannot modify recordings"));
-    }
-    Ok(())
-}
-
 fn assert_workspace_member(
     state: &AppState,
     workspace_id: &str,
     principal: &Principal,
 ) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
     let db = state.db.lock().unwrap();
-    db.get_workspace_member_role(workspace_id, &principal.username)
+    db.workspace_access(workspace_id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
         .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
     Ok(())
@@ -4549,7 +4541,7 @@ async fn handle_init_recording(
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
     let principal = validate_principal(&headers, &state)?;
     require_password_changed(&state, &principal)?;
-    assert_workspace_writer(&state, &workspace_id, &principal)?;
+    assert_workspace_member(&state, &workspace_id, &principal)?;
 
     let s3 = state.s3.as_ref().ok_or_else(s3_unavailable)?;
 
@@ -4587,7 +4579,7 @@ async fn handle_complete_recording(
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
     let principal = validate_principal(&headers, &state)?;
     require_password_changed(&state, &principal)?;
-    assert_workspace_writer(&state, &workspace_id, &principal)?;
+    assert_workspace_member(&state, &workspace_id, &principal)?;
 
     let s3 = state.s3.as_ref().ok_or_else(s3_unavailable)?;
 
@@ -4681,7 +4673,7 @@ async fn handle_delete_recording(
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
     let principal = validate_principal(&headers, &state)?;
     require_password_changed(&state, &principal)?;
-    assert_workspace_writer(&state, &workspace_id, &principal)?;
+    assert_workspace_member(&state, &workspace_id, &principal)?;
 
     // Tear down DB first to release the s3_key for cleanup; if S3 delete
     // fails the worst case is an orphan object — we log but don't surface.
@@ -4718,7 +4710,7 @@ struct RegisterPeerRequest {
 }
 
 /// Returns the workspace's federation channel secret and the live peer list.
-/// Any workspace member (incl. viewers) can read — the secret is the symmetric
+/// Any workspace member can read — the secret is the symmetric
 /// key for the ZMQ data plane that all member fusionhubs need to participate.
 async fn handle_get_workspace_federation(
     State(state): State<Arc<AppState>>,
@@ -4729,7 +4721,7 @@ async fn handle_get_workspace_federation(
     require_password_changed(&state, &principal)?;
 
     let db = state.db.lock().unwrap();
-    db.get_workspace_member_role(&workspace_id, &principal.username)
+    db.workspace_access(&workspace_id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
         .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
 
@@ -4793,7 +4785,7 @@ async fn handle_get_workspace_graph(
     require_password_changed(&state, &principal)?;
 
     let db = state.db.lock().unwrap();
-    db.get_workspace_member_role(&workspace_id, &principal.username)
+    db.workspace_access(&workspace_id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
         .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
 
@@ -4814,7 +4806,7 @@ async fn handle_get_workspace_graph(
 
 /// Optimistic-lock upsert of the workspace's graph. The request body carries
 /// the version the editor was loaded with; mismatch ⇒ 409 with the current
-/// version so the editor can refresh + reapply. Viewers cannot write.
+/// version so the editor can refresh + reapply.
 async fn handle_put_workspace_graph(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -4825,12 +4817,9 @@ async fn handle_put_workspace_graph(
     require_password_changed(&state, &principal)?;
 
     let db = state.db.lock().unwrap();
-    let role = db.get_workspace_member_role(&workspace_id, &principal.username)
+    db.workspace_access(&workspace_id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
         .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
-    if role == "viewer" {
-        return Err(error_response(StatusCode::FORBIDDEN, "Viewers cannot edit the workspace graph"));
-    }
 
     let config_str = serde_json::to_string(&req.config)
         .map_err(|e| error_response(StatusCode::BAD_REQUEST, &format!("config not serialisable: {}", e)))?;
@@ -4852,7 +4841,6 @@ async fn handle_put_workspace_graph(
 
 /// Register (or refresh) a FusionHub peer for this workspace. Idempotent on
 /// `(workspace_id, host_id)` — re-registration updates `url`/`label`/`last_seen`.
-/// Viewers cannot register peers (read-only role).
 async fn handle_register_workspace_peer(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -4870,12 +4858,9 @@ async fn handle_register_workspace_peer(
     }
 
     let db = state.db.lock().unwrap();
-    let role = db.get_workspace_member_role(&workspace_id, &principal.username)
+    db.workspace_access(&workspace_id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
         .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
-    if role == "viewer" {
-        return Err(error_response(StatusCode::FORBIDDEN, "Viewers cannot register peers"));
-    }
 
     db.upsert_workspace_peer(&workspace_id, &req.host_id, &req.url, &req.label, &req.network_id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
@@ -4883,7 +4868,7 @@ async fn handle_register_workspace_peer(
     Ok(Json(serde_json::json!({ "status": "OK" })))
 }
 
-/// Remove a FusionHub peer from this workspace. Viewers cannot revoke.
+/// Remove a FusionHub peer from this workspace.
 async fn handle_delete_workspace_peer(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -4893,12 +4878,9 @@ async fn handle_delete_workspace_peer(
     require_password_changed(&state, &principal)?;
 
     let db = state.db.lock().unwrap();
-    let role = db.get_workspace_member_role(&workspace_id, &principal.username)
+    db.workspace_access(&workspace_id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
         .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
-    if role == "viewer" {
-        return Err(error_response(StatusCode::FORBIDDEN, "Viewers cannot remove peers"));
-    }
 
     let removed = db.delete_workspace_peer(&workspace_id, &host_id)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
@@ -4910,7 +4892,7 @@ async fn handle_delete_workspace_peer(
 }
 
 /// Rotate the workspace's federation channel secret. Forces every connected
-/// FusionHub to re-fetch on next poll and rekey. Owner/editor only.
+/// FusionHub to re-fetch on next poll and rekey. Any workspace member.
 async fn handle_rotate_workspace_federation(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -4920,12 +4902,9 @@ async fn handle_rotate_workspace_federation(
     require_password_changed(&state, &principal)?;
 
     let db = state.db.lock().unwrap();
-    let role = db.get_workspace_member_role(&workspace_id, &principal.username)
+    db.workspace_access(&workspace_id, &principal.username)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
         .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
-    if role == "viewer" {
-        return Err(error_response(StatusCode::FORBIDDEN, "Viewers cannot rotate secrets"));
-    }
 
     let new_secret = db.rotate_workspace_federation_secret(&workspace_id)
         .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
@@ -4944,7 +4923,7 @@ async fn handle_workspace_releases(
 
     let (rows, mut assets_by_id) = {
         let db = state.db.lock().unwrap();
-        db.get_workspace_member_role(&workspace_id, &principal.username)
+        db.workspace_access(&workspace_id, &principal.username)
             .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
             .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
 
@@ -4976,7 +4955,7 @@ async fn handle_workspace_releases(
 }
 
 /// List doc-bearing releases scoped to a single workspace. Workspace members
-/// (any role) and site admins may call this; non-members get 403. Mirrors
+/// and site admins may call this; non-members get 403. Mirrors
 /// `handle_list_doc_releases` but filtered to one workspace.
 async fn handle_list_workspace_doc_releases(
     State(state): State<Arc<AppState>>,
@@ -4985,9 +4964,9 @@ async fn handle_list_workspace_doc_releases(
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
     let principal = validate_principal(&headers, &state)?;
     require_password_changed(&state, &principal)?;
-    if !is_site_admin(&state, &principal) {
+    {
         let db = state.db.lock().unwrap();
-        db.get_workspace_member_role(&workspace_id, &principal.username)
+        db.workspace_access(&workspace_id, &principal.username)
             .map_err(|e| error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
             .ok_or_else(|| error_response(StatusCode::FORBIDDEN, "Not a member of this workspace"))?;
     }
@@ -5391,6 +5370,7 @@ async fn main() -> Result<()> {
         .route("/api/v1/auth/users/{username}", axum::routing::delete(handle_delete_user))
         .route("/api/v1/auth/users/{username}/email", axum::routing::put(handle_set_user_email))
         .route("/api/v1/auth/users/{username}/rename", post(handle_rename_user))
+        .route("/api/v1/auth/users/{username}/role", axum::routing::put(handle_set_user_role))
         .route("/api/v1/auth/users/{username}/reset-password", post(handle_reset_user_password))
         .route("/api/v1/auth/users/{username}/resend-invitation", post(handle_resend_invitation))
         // Public client endpoints

--- a/crates/susi_server/tests/integration.rs
+++ b/crates/susi_server/tests/integration.rs
@@ -1289,15 +1289,15 @@ fn test_rename_user_migrates_everything() {
 }
 
 /// Rename onto a name that still has orphaned membership rows (e.g. from a
-/// deleted account) must merge instead of failing: one surviving row, the
-/// more privileged role wins, and the whole rename stays atomic.
+/// deleted account) must merge instead of failing: one surviving row, and
+/// the whole rename stays atomic.
 #[test]
 fn test_rename_user_merges_conflicting_memberships() {
     let server = TestServer::start();
     let admin = server.admin_token();
     let client = server.http();
 
-    for (name, _role) in [("merge_x", "viewer"), ("merge_y", "owner")] {
+    for name in ["merge_x", "merge_y"] {
         client
             .post(format!("{}/auth/users", server.api_url))
             .bearer_auth(&admin)
@@ -1323,11 +1323,11 @@ fn test_rename_user_merges_conflicting_memberships() {
         .expect("ws json");
     let ws_id = ws["id"].as_str().expect("ws id").to_string();
 
-    for (name, role) in [("merge_x", "viewer"), ("merge_y", "owner")] {
+    for name in ["merge_x", "merge_y"] {
         client
             .post(format!("{}/workspaces/{}/members", server.api_url, ws_id))
             .bearer_auth(&admin)
-            .json(&json!({"username": name, "role": role}))
+            .json(&json!({"username": name}))
             .send()
             .expect("add member")
             .error_for_status()
@@ -1388,15 +1388,14 @@ fn test_rename_user_merges_conflicting_memberships() {
         .expect("get ws")
         .json::<Value>()
         .expect("ws json");
-    let members: Vec<(&str, &str)> = ws["members"]
+    let members: Vec<&str> = ws["members"]
         .as_array()
         .expect("members")
         .iter()
-        .map(|m| (m["username"].as_str().unwrap(), m["role"].as_str().unwrap()))
+        .map(|m| m["username"].as_str().unwrap())
         .collect();
-    let merge_rows: Vec<_> = members.iter().filter(|(u, _)| *u == "merge_x").collect();
+    let merge_rows: Vec<_> = members.iter().filter(|u| **u == "merge_x").collect();
     assert_eq!(merge_rows.len(), 1, "exactly one surviving membership: {:?}", members);
-    assert_eq!(merge_rows[0].1, "owner", "more privileged role must win: {:?}", members);
 
     // Config-revision authorship follows the rename.
     let configs = client
@@ -1413,4 +1412,192 @@ fn test_rename_user_merges_conflicting_memberships() {
         .clone();
     assert!(!revs.is_empty(), "expected a config revision: {}", configs);
     assert_eq!(revs[0]["author"], json!("merge_x"), "author must follow rename: {}", configs);
+}
+
+/// A site admin who is not a member of a workspace must still have full access
+/// (read detail, manage members, push configs) - the same as an owner/editor
+/// member. Non-admin non-members stay denied.
+#[test]
+fn test_admin_non_member_has_full_workspace_access() {
+    let server = TestServer::start();
+    let admin = server.admin_token();
+    let client = server.http();
+
+    // Admin creates a workspace (auto-added as a member), then removes its own
+    // membership so it is a pure non-member site admin.
+    let ws_id = client
+        .post(format!("{}/workspaces", server.api_url))
+        .bearer_auth(&admin)
+        .json(&json!({"name": "Admin Access WS", "product": "fusionhub", "description": ""}))
+        .send()
+        .expect("create ws")
+        .json::<Value>()
+        .expect("ws json")["id"]
+        .as_str()
+        .expect("ws id")
+        .to_string();
+
+    client
+        .delete(format!("{}/workspaces/{}/members/admin", server.api_url, ws_id))
+        .bearer_auth(&admin)
+        .send()
+        .expect("remove self membership")
+        .error_for_status()
+        .expect("remove ok");
+
+    // Non-member admin can still read the workspace detail.
+    let resp = client
+        .get(format!("{}/workspaces/{}", server.api_url, ws_id))
+        .bearer_auth(&admin)
+        .send()
+        .expect("get ws");
+    assert!(resp.status().is_success(), "admin get ws: {}", resp.text().unwrap_or_default());
+    let ws = resp.json::<Value>().expect("ws json");
+    assert_eq!(ws["name"], json!("Admin Access WS"), "admin sees workspace detail: {}", ws);
+
+    // ... and manage members.
+    client
+        .post(format!("{}/auth/users", server.api_url))
+        .bearer_auth(&admin)
+        .json(&json!({"username": "regular_u", "email": "regular_u@example.com", "role": "user", "password": "regularpass123"}))
+        .send()
+        .expect("create user")
+        .error_for_status()
+        .expect("create user ok");
+    let resp = client
+        .post(format!("{}/workspaces/{}/members", server.api_url, ws_id))
+        .bearer_auth(&admin)
+        .json(&json!({"username": "regular_u"}))
+        .send()
+        .expect("add member");
+    assert!(resp.status().is_success(), "admin add member: {}", resp.text().unwrap_or_default());
+
+    // ... and push a config (write access comes with membership).
+    let resp = client
+        .post(format!("{}/workspaces/{}/configs", server.api_url, ws_id))
+        .bearer_auth(&admin)
+        .json(&json!({"config_json": "{}", "name": "admin rev", "description": ""}))
+        .send()
+        .expect("push config");
+    assert_eq!(resp.status().as_u16(), 201, "admin push config: {}", resp.text().unwrap_or_default());
+
+    // A non-admin who is not a member is still denied.
+    client
+        .post(format!("{}/auth/users", server.api_url))
+        .bearer_auth(&admin)
+        .json(&json!({"username": "outsider", "email": "outsider@example.com", "role": "user", "password": "outsiderpass123"}))
+        .send()
+        .expect("create outsider")
+        .error_for_status()
+        .expect("create outsider ok");
+    let outsider_jwt = client
+        .post(format!("{}/auth/login", server.api_url))
+        .json(&json!({"username": "outsider", "password": "outsiderpass123"}))
+        .send()
+        .expect("login outsider")
+        .json::<Value>()
+        .expect("json")["token"]
+        .as_str()
+        .expect("token")
+        .to_string();
+    client
+        .post(format!("{}/auth/change-password", server.api_url))
+        .bearer_auth(&outsider_jwt)
+        .json(&json!({"current_password": "outsiderpass123", "new_password": "outsiderpass456"}))
+        .send()
+        .expect("change pw")
+        .error_for_status()
+        .expect("change pw ok");
+    let resp = client
+        .get(format!("{}/workspaces/{}", server.api_url, ws_id))
+        .bearer_auth(&outsider_jwt)
+        .send()
+        .expect("outsider get ws");
+    assert_eq!(resp.status().as_u16(), 403, "non-admin non-member must be denied");
+}
+
+/// Admins can promote a user to admin and demote them back, but cannot change
+/// their own role (self-lockout guard). Invalid roles and unknown users are
+/// rejected.
+#[test]
+fn test_set_user_role() {
+    let server = TestServer::start();
+    let admin = server.admin_token();
+    let client = server.http();
+
+    client
+        .post(format!("{}/auth/users", server.api_url))
+        .bearer_auth(&admin)
+        .json(&json!({"username": "promote_me", "email": "promote_me@example.com", "role": "user", "password": "promotepass123"}))
+        .send()
+        .expect("create user")
+        .error_for_status()
+        .expect("create user ok");
+
+    let role_of = |username: &str| -> String {
+        client
+            .get(format!("{}/auth/users", server.api_url))
+            .bearer_auth(&admin)
+            .send()
+            .expect("list users")
+            .json::<Value>()
+            .expect("json")
+            .as_array()
+            .expect("array")
+            .iter()
+            .find(|u| u["username"] == json!(username))
+            .expect("user present")["role"]
+            .as_str()
+            .expect("role")
+            .to_string()
+    };
+
+    assert_eq!(role_of("promote_me"), "user");
+
+    // Promote, then demote.
+    let resp = client
+        .put(format!("{}/auth/users/promote_me/role", server.api_url))
+        .bearer_auth(&admin)
+        .json(&json!({"role": "admin"}))
+        .send()
+        .expect("promote");
+    assert!(resp.status().is_success(), "promote: {}", resp.text().unwrap_or_default());
+    assert_eq!(role_of("promote_me"), "admin");
+
+    let resp = client
+        .put(format!("{}/auth/users/promote_me/role", server.api_url))
+        .bearer_auth(&admin)
+        .json(&json!({"role": "user"}))
+        .send()
+        .expect("demote");
+    assert!(resp.status().is_success(), "demote: {}", resp.text().unwrap_or_default());
+    assert_eq!(role_of("promote_me"), "user");
+
+    // Cannot change own role.
+    let resp = client
+        .put(format!("{}/auth/users/admin/role", server.api_url))
+        .bearer_auth(&admin)
+        .json(&json!({"role": "user"}))
+        .send()
+        .expect("self role");
+    assert_eq!(resp.status().as_u16(), 400, "self role-change must be rejected");
+    assert_eq!(role_of("admin"), "admin", "admin must remain admin");
+
+    // Invalid role rejected.
+    let resp = client
+        .put(format!("{}/auth/users/promote_me/role", server.api_url))
+        .bearer_auth(&admin)
+        .json(&json!({"role": "superuser"}))
+        .send()
+        .expect("bad role");
+    assert_eq!(resp.status().as_u16(), 400, "invalid role must be rejected");
+
+    // Unknown user -> 404.
+    let resp = client
+        .put(format!("{}/auth/users/ghost/role", server.api_url))
+        .bearer_auth(&admin)
+        .json(&json!({"role": "admin"}))
+        .send()
+        .expect("ghost role");
+    assert_eq!(resp.status().as_u16(), 404, "unknown user must 404");
 }


### PR DESCRIPTION
## Summary
- Site admins now have full access to every workspace (view detail, manage members, configs, recordings, graph) without being a member.
- Add `PUT /api/v1/auth/users/{username}/role` to change a user's site role (admin/user), with a self-lockout guard; surfaced as a "Make/Revoke admin" action in the dashboard users table.
- Remove the per-member workspace roles (viewer/editor/owner): workspace membership now grants full read+write, while management (add/remove members, create/delete workspace) stays site-admin-only. Drops the `workspace_members.role` column.
- Remove the defunct Instances tab from the workspace dashboard (instance self-registration was removed from FusionHub).

## Notes
- The DB migration drops `workspace_members.role` on startup (idempotent; no-op on fresh DBs). No external consumer used the workspace member role field.
- The `/federation` peer-registration endpoints are now UI-dead but were left in place since that endpoint still serves the channel secret + graph version used by workspace graph sync.

## Testing
- susi_core unit tests and susi_server integration tests pass, including new tests for admin workspace access and the user-role endpoint.
- Verified on staging and production (health green, migration applied cleanly).